### PR TITLE
Otman/ssj updates: Add randomized Rank-1 lattice RQMC tests and prime lookup constants

### DIFF
--- a/src/main/docs/examples/rqmcexperiments/HistLat2.java
+++ b/src/main/docs/examples/rqmcexperiments/HistLat2.java
@@ -1,0 +1,361 @@
+package rqmcexperiments;
+
+import java.io.*;
+import java.util.Arrays;
+import java.util.Formatter;
+import java.util.Locale;
+import umontreal.ssj.stat.*; 
+
+/**
+ * This program reads the .dat files created by `WSC23MoreReps.java`, which
+ * contain RQMC replicates for various functions and methods, and creates a
+ * LaTeX file with a 3x4 table of histograms of the RQMC errors, with one row
+ * for each method type (Lat, Lat-Rv, Lat-Rp) and one column for each value of
+ * `k` (number of points @f$n=2^k@f$). Each histogram has a title with the
+ * function name and the method, and a legend with the variance, skewness and
+ * excess kurtosis of the data. The output LaTeX file can be compiled to create
+ * a PDF with the histograms.
+ */
+
+
+// Needs to be more organized and better documented, but it works for now.
+//The code should be revised to be cleaner,
+//but I wanted to get the results out first.
+// If we could get stats from the TallyHistogram directly, that would be better than reading the file twice.
+	
+public class HistLat2 {
+
+   public static void main(String[] args) throws IOException {
+
+      String dataDir = "/home/otman/Documents/GitHub/Data/wsc23-test/";// .dat files should be here
+      String latexDir = "/home/otman/Documents/GitHub/Data/tikz-latx/";// output .tex file will be created here
+
+      //Important: Change these parameters as needed to match the .dat files you have.
+      String modelTag = "SmoothGauss";
+      int s = 8;
+      int m = 10000;
+      boolean baker = true;
+      int[] ks = {10, 12, 14, 16};
+
+      
+      
+      String baseTag = modelTag + "-" + s;
+
+      String pageTitle;
+      String[][] methodCandidates;
+
+      if (!baker) {
+         pageTitle = "RQMC Rank-1 lattice point set comparison: "
+               + modelTag + "-" + s + " ($10^4$ samples)";
+
+         methodCandidates = new String[][] {
+            {"Lat-RS"},
+            {"Lat-RvRS", "Lat-Rv-RS"},
+            {"Lat-RpvRS", "Lat-RpRS", "Lat-Rp-RS", "Lat-Rpv-RS"}
+         };
+      } else {
+         pageTitle = "RQMC Rank-1 lattice point set comparison: "
+               + modelTag + "-baker-" + s + " ($10^4$ samples)";
+
+         methodCandidates = new String[][] {
+            {"Lat-RSB", "Lat-RST"},
+            {"Lat-RvRSB", "Lat-RvRST", "Lat-Rv-RSB", "Lat-Rv-RST"},
+            {"Lat-RpvRSB", "Lat-RpvRST", "Lat-Rp-RSB", "Lat-Rp-RST", "Lat-Rpv-RSB", "Lat-Rpv-RST"}
+         };
+      }
+
+      String[] rowLabels = {"Lat", "Lat-Rv", "Lat-Rp"};
+
+      File inputFolder = new File(dataDir);
+      File outputFolder = new File(latexDir);
+      outputFolder.mkdirs();
+
+      File[] files = inputFolder.listFiles((dir, name) -> name.endsWith(".dat"));
+
+      if (files == null || files.length == 0) {
+         System.out.println("No .dat files found in " + dataDir);
+         return;
+      }
+
+      Arrays.sort(files);
+
+      String outputName = baker
+            ? modelTag + "-baker-" + s + "_rank1_12plots.tex"
+            : modelTag + "-" + s + "_rank1_12plots.tex";
+
+      File outFile = new File(outputFolder, outputName);
+
+      try (PrintWriter out = new PrintWriter(new FileWriter(outFile))) {
+
+         out.println("\\documentclass[border=3pt]{standalone}");
+         out.println("\\usepackage{amsmath}");
+         out.println("\\usepackage{graphicx}");
+         out.println("\\usepackage{pgfplots}");
+         out.println("\\pgfplotsset{compat=1.18}");
+         out.println("\\begin{document}");
+         out.println();
+
+         out.println("\\begin{tabular}{@{}r@{\\hspace{1mm}}c@{\\hspace{1mm}}c@{\\hspace{1mm}}c@{\\hspace{1mm}}c@{}}");
+         out.println("\\multicolumn{5}{c}{\\fontsize{7}{8}\\selectfont\\textbf{" + pageTitle + "}} \\\\[2mm]");
+
+         for (int r = 0; r < rowLabels.length; r++) {
+
+            out.print("{\\fontsize{6}{7}\\selectfont " + rowLabels[r] + "}");
+
+            for (int c = 0; c < ks.length; c++) {
+               int k = ks[c];
+
+               File file = findFile(files, baseTag, methodCandidates[r], k, m);
+
+               if (file == null) {
+                  out.print(" & {\\tiny Missing}");
+                  continue;
+               }
+
+               out.print(" & ");
+               out.println(makeHistogramLatex(file));
+            }
+
+            out.println("\\\\[1.5mm]");
+         }
+
+         out.print("{}");
+         for (int k : ks) {
+            out.print(" & {\\fontsize{6}{7}\\selectfont $n=2^{" + k + "}$}");
+         }
+         out.println(" \\\\");
+
+         out.println("\\end{tabular}");
+         out.println();
+         out.println("\\end{document}");
+      }
+
+      System.out.println("LaTeX file created:");
+      System.out.println(outFile.getAbsolutePath());
+   }
+
+   private static File findFile(File[] files, String baseTag, String[] methodCandidates, int k, int m) {
+
+      for (String method : methodCandidates) {
+         String exactName = baseTag + "-" + method + "-" + k + "-" + m + ".dat";
+
+         for (File file : files) {
+            if (file.getName().equals(exactName))
+               return file;
+         }
+      }
+
+      for (String method : methodCandidates) {
+         String prefix = baseTag + "-" + method + "-" + k + "-";
+
+         for (File file : files) {
+            if (file.getName().startsWith(prefix) && file.getName().endsWith(".dat"))
+               return file;
+         }
+      }
+
+      return null;
+   }
+
+   private static String makeHistogramLatex(File file) throws IOException {
+
+      FileStats stats = getFileStats(file);
+
+      double xmin = stats.min;
+      double xmax = stats.max;
+
+      if (xmin == xmax) {
+         xmin -= 1.0;
+         xmax += 1.0;
+      } else {
+         double pad = 0.03 * (xmax - xmin);
+         xmin -= pad;
+         xmax += pad;
+      }
+
+      int numBins = Math.max(20, (int) Math.round(2*Math.cbrt(stats.numObs)));
+
+      TallyHistogram hist = new TallyHistogram(xmin, xmax, numBins); 
+      hist.fillFromFile(file.getAbsolutePath());
+
+      ScaledHistogram scHist = new ScaledHistogram(hist, 1.0);
+
+      String title = cleanTitle(file.getName());
+
+      String legend =
+    	      "\\scalebox{0.62}{"
+    	      + "\\begin{tabular}{@{}l@{}}"
+    	      + "$\\sigma^2$=" + sci(hist.variance())
+    	      + "\\\\[-1pt]$\\gamma$=" + sci(stats.skewness)
+    	      + "\\\\[-1pt]$\\kappa'$=" + sci(stats.excessKurtosis)
+    	      + "\\end{tabular}"
+    	      + "}";
+
+      scHist.setAxisOptions(
+         "title={" + escapeLatex(title) + "}, " +
+
+         // Smaller title font.
+         "title style={font=\\fontsize{5}{5.5}\\selectfont}, " +
+
+         // Bigger plot box.
+         "width=5.15cm, height=4.01cm, " +
+
+         "xlabel={}, ylabel={}, " +
+         "scaled x ticks=true, " +
+         "scaled y ticks=false, " +
+
+         // Smaller tick labels.
+         "tick label style={font=\\fontsize{4.5}{5}\\selectfont}, " +
+
+         // Smaller  bold x-axis multiplier, e.g. 1e-4.
+         "every x tick scale label/.append style={font=\\fontsize{4}{4.5}\\selectfont\\bfseries\\boldmath, yshift=5pt}, "  +
+         "every y tick scale label/.append style={font=\\fontsize{4}{4.5}\\selectfont}, " +
+
+         // Red vertical line at 0.
+//         "extra x ticks={0}, " +
+//         "extra x tick labels={}, " +
+//         "extra x tick style={grid=major, major grid style={red, thick}}, " +
+
+         // Smaller legend rectangle.
+         "legend entries={{" + legend + "}}, " +
+         "legend image code/.code={}, " +
+         "legend style={"
+            + "draw=none, "
+            + "fill=none, "
+            + "font=\\scriptsize, "
+            + "cells={anchor=west}, "
+            + "inner xsep=0pt, "
+            + "inner ysep=0pt"
+         + "}, " +
+         "legend pos=north east"
+      );
+
+      scHist.setAddPlotOptions("fill=blue, draw=black");
+
+      return scHist.toLatex(true, false);
+   }
+
+   private static String cleanTitle(String fileName) {
+      String title = fileName.substring(0, fileName.length() - 4);
+      title = title.replaceFirst("-\\d+$", "");
+      return title;
+   }
+
+   private static FileStats getFileStats(File file) throws IOException {
+      FileStats stats = new FileStats();
+
+      double sum = 0.0;
+
+      try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+         String line;
+
+         while ((line = reader.readLine()) != null) {
+            line = cleanDataLine(line);
+
+            if (line.isEmpty())
+               continue;
+
+            String[] values = line.split("\\s+");
+
+            for (String value : values) {
+               double x = Double.parseDouble(value);
+
+               if (x < stats.min)
+                  stats.min = x;
+               if (x > stats.max)
+                  stats.max = x;
+
+               sum += x;
+               stats.numObs++;
+            }
+         }
+      }
+
+      if (stats.numObs == 0)
+         throw new IOException("No observations found in " + file.getAbsolutePath());
+
+      stats.mean = sum / stats.numObs;
+
+      double m2 = 0.0;
+      double m3 = 0.0;
+      double m4 = 0.0;
+
+      try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+         String line;
+
+         while ((line = reader.readLine()) != null) {
+            line = cleanDataLine(line);
+
+            if (line.isEmpty())
+               continue;
+
+            String[] values = line.split("\\s+");
+
+            for (String value : values) {
+               double x = Double.parseDouble(value);
+               double d = x - stats.mean;
+               double d2 = d * d;
+
+               m2 += d2;
+               m3 += d2 * d;
+               m4 += d2 * d2;
+            }
+         }
+      }
+
+
+      double m2n = m2 / stats.numObs;
+      double m3n = m3 / stats.numObs;
+      double m4n = m4 / stats.numObs;
+
+      if (m2n > 0.0) {
+         stats.skewness = m3n / Math.pow(m2n, 1.5);
+         stats.excessKurtosis = m4n / (m2n * m2n) - 3.0;
+      } else {
+         stats.skewness = 0.0;
+         stats.excessKurtosis = 0.0;
+      }
+
+      return stats;
+   }
+
+   private static String cleanDataLine(String line) {
+      line = line.trim();
+
+      if (line.isEmpty())
+         return "";
+
+      int commentIndex = line.indexOf('#');
+
+      if (commentIndex >= 0)
+         line = line.substring(0, commentIndex).trim();
+
+      return line;
+   }
+
+   private static String sci(double x) {
+      Formatter formatter = new Formatter(Locale.US);
+      formatter.format("%.1e", x);
+      String s = formatter.toString();
+      formatter.close();
+
+      s = s.replace("e-0", "e-");
+      s = s.replace("e+0", "e");
+      s = s.replace("e+", "e");
+
+      return s;
+   }
+
+   private static String escapeLatex(String s) {
+      return s.replace("_", "\\_");
+   }
+
+   private static class FileStats {
+      int numObs = 0;
+      double min = Double.POSITIVE_INFINITY;
+      double max = Double.NEGATIVE_INFINITY;
+      double mean = 0.0;
+      double skewness = 0.0;
+      double excessKurtosis = 0.0;
+   }
+}

--- a/src/main/docs/examples/rqmcexperiments/HistLatex.java
+++ b/src/main/docs/examples/rqmcexperiments/HistLatex.java
@@ -17,65 +17,67 @@ public class HistLatex {
    public static void main(String[] args) throws IOException {
 
       // String directory = "C:/Users/Lecuyer/Dropbox/samo25/paperdat/";  // For testing
-      String directory = "C:/Users/Lecuyer/Dropbox/wsc23/test/";      // For testing
+	  String directory = "C:/Users/Lecuyer/Dropbox/wsc23/test/";      // For testing
+
+      //String directory = "/home/otman/Documents/GitHub/Data/wsc23-test/";      // For testing
       
       // double xmin = -5.2E-12;
       // double xmax =  5.2E-12;
-      double xmin = -1.4E-4;
-      double xmax =  1.4E-4;
+      double xmin = - 1.1E-2;
+      double xmax =  -xmin;
       int numBins = 40;
+
       // int numObs  = 1000000;
      
-      xmax = 1.1E-4;
-      xmin = -xmax;
       TallyHistogram hist = new TallyHistogram(xmin, xmax, numBins);
       // hist.fillFromFile(directory + "SmoothPerB4-8-Lat-RS-16.dat");
-      hist.fillFromFile(directory + "SmoothPerB4-8-Sob-LMS-RDS-16-1000000.dat");
+      hist.fillFromFile(directory + "SumUeU-16-Lat-RvRS-10-10000.dat");
       // ScaledHistogram histScaled = new ScaledHistogram(hist, 1.0);
       // String histStr = histScaled.toLatex(false, true);
       ScaledHistogram scHist = new ScaledHistogram(hist, 1.0);
       scHist.setAxisOptions(
-    		   "title={SmoothPerB4-8-Sob-LMS-RDS-16}, " +
-    		   "title style={font=\\scriptsize}, " +
-    		   "xlabel={$x$}, ylabel={Density}, " +
+    		   "title={SumUeU-16-Lat-RvRS-10-10000}, " +
+    		   "title style={font=\\fontsize{5}{5.5}\\selectfont}, " +
     		   "width=8cm, height=5cm, " +
+    		   "xlabel={}, ylabel={}, " +
+    		   "scaled x ticks=true, " +
     		   "scaled y ticks=false, " +
-    		   "x tick label style={font=\\scriptsize}, " +
-    		   "every x tick scale label/.append style={font=\\scriptsize\\bfseries\\boldmath}, " +
-    		   "legend entries={{\\shortstack[l]{xmin=" + xmin +
-    		   "\\\\ xmax=" + xmax +
-    		   "\\\\ numBins=" + numBins + "}}}, " +
+    		   "tick label style={font=\\fontsize{6}{6.5}\\selectfont}, " +
+    		   "every x tick scale label/.append style={font=\\fontsize{5}{5.5}\\selectfont\\bfseries\\boldmath, yshift=5pt}, " +
+    		   "legend entries={{$\\mathrm{Var}=" 
+    		   + String.format(java.util.Locale.US, "%.2e", hist.variance()) 
+    		   + "$}}, " +
     		   "legend image code/.code={}, " +
-    		   "legend style={draw=black, fill=white, font=\\scriptsize, cells={anchor=west}}, " +
+    		   "legend style={draw=none, fill=none, font=\\scriptsize, cells={anchor=west}, inner xsep=0pt, inner ysep=0pt}, " +
     		   "legend pos=north east"
     		);
       scHist.setAddPlotOptions("fill=red!30, draw=black");
       System.out.println(scHist.toLatex(true, false));
       
-      xmax = 1.25E-6;
+      xmax = 1.25E-2;
       xmin = -xmax;
       hist = new TallyHistogram(xmin, xmax, numBins);
-      hist.fillFromFile(directory + "MC2-8-Sob-LMS-RDS-16-1000000.dat");
+      hist.fillFromFile(directory + "SumUeU-16-Lat-RvRS-10-10000.dat");
       // histScaled = new ScaledHistogram(hist, 1.0);
       // histStr = histScaled.toLatex(false, true);
       scHist = new ScaledHistogram(hist, 1.0);
 
       scHist.setAxisOptions(
-    		   "title={MC2-8-Sob-LMS-RDS-16}, " +
-    		   "title style={font=\\scriptsize}, " +
-    		   "xlabel={$x$}, ylabel={Density}, " +
+    		   "title={SumUeU-16-Lat-RvRS-10-10000}, " +
+    		   "title style={font=\\fontsize{5}{5.5}\\selectfont}, " +
     		   "width=8cm, height=5cm, " +
+    		   "xlabel={}, ylabel={}, " +
+    		   "scaled x ticks=true, " +
     		   "scaled y ticks=false, " +
-    		   "x tick label style={font=\\scriptsize}, " +
-    		   "every x tick scale label/.append style={font=\\scriptsize\\bfseries\\boldmath}, " +
-    		   "legend entries={{\\shortstack[l]{xmin=" + xmin +
-    		   "\\\\ xmax=" + xmax +
-    		   "\\\\ numBins=" + numBins + "}}}, " +
+    		   "tick label style={font=\\fontsize{6}{6.5}\\selectfont}, " +
+    		   "every x tick scale label/.append style={font=\\fontsize{5}{5.5}\\selectfont\\bfseries\\boldmath, yshift=5pt}, " +
+    		   "legend entries={{$\\mathrm{Var}=" 
+    		   + String.format(java.util.Locale.US, "%.2e", hist.variance()) 
+    		   + "$}}, " +
     		   "legend image code/.code={}, " +
-    		   "legend style={draw=black, fill=white, font=\\scriptsize, cells={anchor=west}}, " +
+    		   "legend style={draw=none, fill=none, font=\\scriptsize, cells={anchor=west}, inner xsep=0pt, inner ysep=0pt}, " +
     		   "legend pos=north east"
     		);
-    		
       scHist.setAddPlotOptions("fill=blue!30, thick");
       System.out.println(scHist.toLatex(false, true));
    }

--- a/src/main/docs/examples/rqmcexperiments/WSC23MoreSamples.java
+++ b/src/main/docs/examples/rqmcexperiments/WSC23MoreSamples.java
@@ -73,16 +73,23 @@ public class WSC23MoreSamples extends RQMCExperiment64 {
     * Performs m independent RQMC replications and save the sorted output in the
     * `statReps` collector.
     */
+   
+   // Note: the randomization is applied to the point set at each replication,
+   //which can change the number of points n, as with random prime n. 
+   //So we create the iterator and get n inside the loop, after randomization.
+   //Maybe it's better to do it only for the random prime n case ??
    public static void simulRepsRQMCSort(MonteCarloModelDouble model, PointSet p, 
          PointSetRandomization rand, int m, TallyStore statReps) throws IOException {
       statReps.init();
-      int n = p.getNumPoints();
+      //int n = p.getNumPoints(); // Moved in the loop in case the randomization changes n, as with random prime n.
       Tally statValue = new Tally();
-      PointSetIterator stream = p.iterator();
+      //PointSetIterator stream = p.iterator(); // Moved in the loop ??
       Chrono timer = new Chrono();
       for (int rep = 0; rep < m; rep++) {
          statValue.init();
          rand.randomize(p);
+         int n = p.getNumPoints(); // In case the randomization changes n, as with random prime n.
+         PointSetIterator stream = p.iterator(); // Create a new iterator for the (possibly) new point set after randomization.
          stream.resetStartStream(); // This stream iterates over the points.
          simulateRuns(model, n, stream, statValue);
          statReps.add(statValue.average()); // For the estimator of the mean.
@@ -120,10 +127,10 @@ public class WSC23MoreSamples extends RQMCExperiment64 {
       RandomShift randShift = new RandomShift(stream);
       BakerTransformedPointSet ptent = new BakerTransformedPointSet(pLat);
 
-      // Lat-RS
-      System.out.println("*   Lattice points with RS");
-      statReps.setName(modelTag + "-" + s + "-Lat-RS-" + k + "-" + m);      
-      simulRepsRQMCSort(model, pLat, randShift, m, statReps);
+//      // Lat-RS
+//      System.out.println("*   Lattice points with RS");
+//      statReps.setName(modelTag + "-" + s + "-Lat-RS-" + k + "-" + m);      
+//      simulRepsRQMCSort(model, pLat, randShift, m, statReps);
 
       // Lat-RSB
       System.out.println("*   Lattice points with RS + tent transform");
@@ -131,16 +138,78 @@ public class WSC23MoreSamples extends RQMCExperiment64 {
       simulRepsRQMCSort(model, ptent, randShift, m, statReps);
 
       // Lat-RvRS, random a
-      //System.out.println("*   Lattice points with random gen vector a and RS");
-      //statReps.setName(modelTag + "-" + s + "-Lat-RS-" + k + "-" + m);      
-      //simulRepsRQMCSort(model, pLat, randShift, m, statReps);
+//      System.out.println("*   Lattice points with random gen vector a and RS");
+//      statReps.setName(modelTag + "-" + s + "-Lat-RS-" + k + "-" + m);      
+//      simulRepsRQMCSort(model, pLat, randShift, m, statReps);
      
       // Lat-RvRSB, random a
-      //System.out.println("*   Lattice points with random gen vector a and RS + tent");
-      //statReps.setName(modelTag + "-" + s + "-Lat-RS-" + k + "-" + m);      
-      //simulRepsRQMCSort(model, pLat, randShift, m, statReps);
+//      System.out.println("*   Lattice points with random gen vector a and RS + tent");
+//      statReps.setName(modelTag + "-" + s + "-Lat-RS-" + k + "-" + m);      
+//      simulRepsRQMCSort(model, pLat, randShift, m, statReps);
+      
+      
+      
+      
+      
+      //The rest of Lattice cases is added by Otman:
+      
+      
+      
+      // Lat-RvRS: random generating vector a + random shift
+//      System.out.println("*   Lattice points with random gen vector a and RS"); 
+//      Rank1Lattice pLatRvRS = new Rank1Lattice(n, a18, s); // Create a rank-1 lattice with n points, initial vector a18, and dimension s.
+        RandomLatticeParams randLatP = new RandomLatticeParams(true, stream); // Create a randomization that will randomly replace the lattice vector a for power-of-2 n, and also apply a random shift.
+//      statReps.setName(modelTag + "-" + s + "-Lat-RvRS-" + k + "-" + m); 
+//      simulRepsRQMCSort(model, pLatRvRS, randLatP, m, statReps); // Run m replications; at each replication, randomize a, apply random shift
 
-      // -------------      
+
+      // Lat-RvRSB: random generating vector a + random shift + tent transform
+      System.out.println("*   Lattice points with random gen vector a and RS + tent transform"); 
+      Rank1Lattice pLatRvRST = new Rank1Lattice(n, a18, s); // Create a rank-1 lattice with n points, initial vector a18, and dimension s.
+      BakerTransformedPointSet ptentRvRST = new BakerTransformedPointSet(pLatRvRST); // Wrap the lattice with a baker/tent transform.
+      statReps.setName(modelTag + "-" + s + "-Lat-RvRST-" + k + "-" + m); 
+      simulRepsRQMCSort(model, ptentRvRST, randLatP, m, statReps); // Run m replications; at each replication, randomize a, apply random shift, then use the tent-transformed points.
+
+
+//      // Lat-Rv: random generating vector a, no random shift
+//      System.out.println("*   Lattice points with random gen vector a, no shift"); 
+//      Rank1Lattice pLatRv = new Rank1Lattice(n, a18, s); // Create a rank-1 lattice with n points, initial vector a18, and dimension s.
+//      randLatP.setRandShift(false); // Disable the random shift, so only the generating vector a is randomized.
+//      statReps.setName(modelTag + "-" + s + "-Lat-Rv-" + k + "-" + m); 
+//      simulRepsRQMCSort(model, pLatRv, randLatP, m, statReps); // Run m replications; at each replication, randomize a only, compute one estimator value, and store it.
+
+      // ------------- 
+   // Random prime n between 2^(k-1) and 2^k. 
+      int nmin = n / 2;//2^k
+      int nmax = n;//2^(k-1)
+
+
+      randLatP = new RandomLatticeParams(nmin, nmax, stream);
+
+//	  // Lat-RpvRS: random prime n + random a + random shift
+//	  System.out.println("*   Lattice points with random prime n, random gen vector a, and RS");
+//	  Rank1Lattice pLatRpvRS = new Rank1Lattice(n, a18, s);
+//	  statReps.setName(modelTag + "-" + s + "-Lat-RpvRS-" + k + "-" + m);
+//	  simulRepsRQMCSort(model, pLatRpvRS, randLatP, m, statReps);
+
+	  // Lat-RpvRSB: random prime n + random a + random shift + tent transform
+	  System.out.println("*   Lattice points with random prime n, random gen vector a, RS + tent transform");
+	  Rank1Lattice pLatRpvRST = new Rank1Lattice(n, a18, s);
+	  BakerTransformedPointSet ptentRpvRST = new BakerTransformedPointSet(pLatRpvRST);
+	  statReps.setName(modelTag + "-" + s + "-Lat-RpvRST-" + k + "-" + m);
+	  simulRepsRQMCSort(model, ptentRpvRST, randLatP, m, statReps);
+//	
+//	  // Lat-Rpv: random prime n + random a, no random shift
+//	  randLatP.setRandShift(false);
+//	  System.out.println("*   Lattice points with random prime n and random gen vector a, no shift");
+//	  Rank1Lattice pLatRpv = new Rank1Lattice(n, a18, s);
+//	  statReps.setName(modelTag + "-" + s + "-Lat-Rpv-" + k + "-" + m);
+//	  simulRepsRQMCSort(model, pLatRpv, randLatP, m, statReps);
+	  
+	  // End of code Added by Otman.
+	       
+	  /**
+	  // -------------
       // Sobol' points
       System.out.println("*** Sobol points ");
       DigitalNetBase2 p = new SobolSequence(k, 53, s); // n = 2^{k} points in s dim.
@@ -185,7 +254,7 @@ public class WSC23MoreSamples extends RQMCExperiment64 {
       simulRepsRQMCSort(model, cp, nus, m, statReps);
 
       
-/*
+
       // Sob-Int2    Sob-interlaced-order2
       System.out.println("*   Interlaced Sobol points with LMS+RDS");
       DigitalNetBase2 p2 = new SobolSequence(k, 60, 2*s);     // n = 2^{k} points in 2s dim.
@@ -194,7 +263,8 @@ public class WSC23MoreSamples extends RQMCExperiment64 {
       // System.out.println(p.formatPoints());
       // simulRepsRQMCSort(model, pitl, nus, m, statReps);
       // simulRepsRQMCSort(model, ptent, nus, m, statReps);
-*/
+	   */
+      
       System.out.println(
             "Total time for simulRepsAllTypes: " + timer.format() + "\n=========================================== \n");
    }

--- a/src/main/java/umontreal/ssj/rng/RandomPrime.java
+++ b/src/main/java/umontreal/ssj/rng/RandomPrime.java
@@ -45,7 +45,7 @@ public class RandomPrime {
    public static boolean isPrime24 (int p) {
       if (p  >= (1 << 24)) return false;
       for (int i = 0; (i < 564); i++) {
-         int pi = primes4096[i];
+         int pi = PRIMES4096[i];
          if (pi * pi > p) return true;
          if (p % pi == 0) return false;
       }
@@ -70,8 +70,15 @@ public class RandomPrime {
       while (true);
    }
    
-   
-   protected static final int primes4096[] = // all primes less than 4096
+   /**
+    * Contains all prime numbers strictly smaller than @f$4096 = 2^{12}@f$.
+    * The primes are stored in increasing order. One has
+    * <tt>PRIMES_LESS_THAN_4096[i]</tt>@f$ = p_i@f$, where @f$p_i@f$ is the
+    * @f$i@f$-th prime number smaller than @f$4096@f$, for
+    * @f$i = 0,\ldots,563@f$.
+    * Thus, the first value is @f$2@f$ and the last value is @f$4093@f$.
+    */
+   protected static final int PRIMES4096[] = 
       {
     	   2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
     	   59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131,
@@ -108,7 +115,8 @@ public class RandomPrime {
     	   3673, 3677, 3691, 3697, 3701, 3709, 3719, 3727, 3733, 3739, 3761, 3767, 3769, 3779, 3793, 3797,
     	   3803, 3821, 3823, 3833, 3847, 3851, 3853, 3863, 3877, 3881, 3889, 3907, 3911, 3917, 3919, 3923,
     	   3929, 3931, 3943, 3947, 3967, 3989, 4001, 4003, 4007, 4013, 4019, 4021, 4027, 4049, 4051, 4057,
-    	   4073, 4079, 4091, 4093};
+    	   4073, 4079, 4091, 4093
+    	   };
 
    
 

--- a/src/main/java/umontreal/ssj/util/Num.java
+++ b/src/main/java/umontreal/ssj/util/Num.java
@@ -25,6 +25,7 @@
 package umontreal.ssj.util;
 
 import cern.jet.math.Bessel;
+import java.math.BigInteger;
 
 /**
  * This class provides various constants and methods to compute numerical
@@ -178,6 +179,37 @@ public class Num {
          7.2057594037927936e16, 1.44115188075855872e17, 2.88230376151711744e17, 5.76460752303423488e17,
          1.152921504606846976e18, 2.305843009213693952e18, 4.611686018427387904e18, 9.223372036854775808e18,
          1.8446744073709551616e19 };
+      
+   /**
+    * Contains the largest prime numbers strictly smaller than the positive powers
+    * of 2. One has <tt>PRIME_LESS_THAN_TWOEXP[j]</tt>@f$
+    * = \max\{p \text{ prime} : p < 2^j\}@f$, for @f$j=2,\ldots,63@f$.
+    * For @f$j=0@f$ and @f$j=1@f$, the value is <tt>0</tt>, since no prime
+    * number is strictly smaller than @f$2^0 = 1@f$ or @f$2^1 = 2@f$.
+    */
+   //The largest prime less than 2^63 is 9223372036854775783.
+   // BigInteger.isProbablePrime(100) was used to find these primes. Which has an error probability of 2^-100.
+   public static final long[] PRIME_LESS_THAN_TWOEXP = {
+       0L,                  0L,                  3L,                  7L,
+       13L,                 31L,                 61L,                 127L,
+       251L,                509L,                1021L,               2039L,
+       4093L,               8191L,               16381L,              32749L,
+       65521L,              131071L,             262139L,             524287L,
+       1048573L,            2097143L,            4194301L,            8388593L,
+       16777213L,           33554393L,           67108859L,           134217689L,
+       268435399L,          536870909L,          1073741789L,         2147483647L,
+       4294967291L,         8589934583L,         17179869143L,        34359738337L,
+       68719476731L,        137438953447L,       274877906899L,       549755813881L,
+       1099511627689L,      2199023255531L,      4398046511093L,      8796093022151L,
+       17592186044399L,     35184372088777L,     70368744177643L,     140737488355213L,
+       281474976710597L,    562949953421231L,    1125899906842597L,   2251799813685119L,
+       4503599627370449L,   9007199254740881L,   18014398509481951L,  36028797018963913L,
+       72057594037927931L,  144115188075855859L, 288230376151711717L, 576460752303423433L,
+       1152921504606846883L, 2305843009213693951L,
+       4611686018427387847L, 9223372036854775783L
+   };
+   
+
 
    /**
     * Contains the precomputed negative powers of 10. One has


### PR DESCRIPTION
This PR updates the WSC23MoreSamples test class by adding new Rank-1 lattice simulation cases with:

*randomized generator vector a
*randomized prime number of points n
*combinations with random shift and tent/baker transformation

It updates simulRepsRQMCSort() so the simulation can correctly handle a randomized n after the point set is randomized.

In Num.java, this PR adds PRIME_LESS_THAN_TWOEXP, a table containing the largest prime strictly smaller than 2^j.

It also  updates the latex options of HistLatex.java.

I also include HistLatex2.java, which is an  optional prototype plotting utility used to generate 4 × 3 boxplots from the simulation results.