### PR TITLE
Develop: Otman Add  rngexperiments, improve MWC jump by n, and allow w = 0 in Genz function

### DIFF
--- a/src/main/docs/examples/rngexperiments/CompareMWCvsCpp.java
+++ b/src/main/docs/examples/rngexperiments/CompareMWCvsCpp.java
@@ -1,0 +1,242 @@
+package rngexperiments;
+
+import java.io.FileWriter;
+import java.io.PrintWriter;
+import java.io.IOException;
+import umontreal.ssj.rng.MWC64k2a2;
+import umontreal.ssj.rng.MWC64k3a2;
+
+
+
+public class CompareMWCvsCpp {
+
+   /*This print same values in c++ tests (MWCSpeed10.res and MWCJump.res)
+    *  but only for MWC64k2a2: for the jumps the coefficients must be changed in MWC64k2a2
+    * Fixed values chosen to match the C++ files:
+    *
+    * TestMWCSpeed.cc / MWCSpeed10.res:
+    *   n = 10^10
+    *   initial state: x1 = x2 = c = 12345
+    *
+    * TestMWCJump.cc / MWCJump.res:
+    *   jumpSize = 5000
+    *   n0 = 4 successive jumps
+    *   n = 1,000,000 jumps for timing
+    *   
+    */
+   private static final long N_SPEED = 10_000_000_000L;
+   private static final long JUMP_SIZE = 5000L;
+   private static final long N_JUMPS = 1000_000L;
+
+   /*
+    * Java state order:
+    *   {x0, x1, carry}
+    *
+    * This corresponds to:
+    *   x0 = x_{n-2}
+    *   x1 = x_{n-1}
+    *   carry = c
+    */
+   private static final long[] SEED = {12345L, 12345L, 12345L};
+
+   public static void main(String[] args) throws IOException {
+	   
+		StringBuilder out = new StringBuilder();
+		   
+		out.append("-----MWC64k2a2Tests------------------\n");
+	   
+	  get_n_frst_values(10);
+      runSpeedRawTest();
+      runSpeedU01Test();
+      runJumpTest(out); // to match c++ jump res coefficients Ai must be changed, coefficient for jumps are commented in the class MWC64k2a2
+
+      
+      System.out.println(out);
+
+//      FileWriter writer = new FileWriter("/home/otman/Documents/GitHub/Data/o-MWC-test/Jumps__precomputing.res");
+//      writer.write(out.toString());
+//      writer.close();
+   }
+   /*
+    * for raw vallues
+    * */
+   private static void get_n_frst_values(int n) {
+	      MWC64k2a2 rng = new MWC64k2a2();
+	      rng.setSeed(SEED);
+           
+	      System.out.println("Using the seed xxxxxx, the first " + n + " vlaues are :");
+	      String raw;
+	      for (long i = 0; i < n; i++) {
+	    	  raw = Long.toUnsignedString(rng.nextRaw()) ;
+	         System.out.println(raw+ "     ");
+	      }
+	      
+   }
+   
+   
+
+   /*
+    * Same idea as the mwc64k2a2 raw speed block in TestMWCSpeed.cc:
+    *
+    * x1 = x2 = c = 12345;
+    * sum = 0;
+    * for i = 0 to n-1:
+    *     sum += mwc64k2a2();
+    *
+    * Java long overflow automatically wraps modulo 2^64.
+    */
+   private static void runSpeedRawTest() {
+      MWC64k2a2 rng = new MWC64k2a2();
+
+      
+      rng.setSeed(SEED);
+      long sum = 0L;
+      long start = System.nanoTime();
+      for (long i = 0; i < N_SPEED; i++) {
+         sum += rng.nextRaw();
+      }
+      long end = System.nanoTime();
+
+      System.out.println("=============================================================");
+      System.out.println("MWC64k raw speed test");
+      System.out.println("n = " + N_SPEED);
+      System.out.println("sum = " + Long.toUnsignedString(sum));
+      System.out.println("time = " + seconds(start, end));
+   }
+
+   /*
+    * Same idea as the U(0,1) speed block in TestMWCSpeed.cc:
+    *
+    * dsum = 0;
+    * for i = 0 to n-1:
+    *     dsum += mwc64k2a2U01();
+    * Java nextValue() uses the top 53 bits and rejects 0.
+    */
+   private static void runSpeedU01Test() {
+      MWC64k2a2 rng = new MWC64k2a2();
+      rng.setSeed(SEED);
+
+      double sum = 0.0;
+
+      long start = System.nanoTime();
+
+      for (long i = 0; i < N_SPEED; i++) {
+         sum += rng.nextDouble();
+      }
+
+      long end = System.nanoTime();
+
+      System.out.println();
+      System.out.println("======================MWC64k2a2=======================================");
+      System.out.println("MWC64k U(0,1) speed test");
+      System.out.println("n = " + N_SPEED);
+      System.out.println("average = " + (sum / N_SPEED));
+      System.out.println("time = " + seconds(start, end));
+   }
+   
+
+   /*
+    * Same structure as MWCJump.res:
+    *
+    * 1. Print initial state.
+    * 2. Make 4 successive jumps of size 5000.
+    * 3. Make one large jump of size 20000 from the initial state.
+    * 4. Make 1,000,000 jumps of size 5000 and print final state + time.
+ * IMPORTANT for MWCJump.res comparison:
+ *
+ * TestMWCJump.cc uses different  constants than TestMWCSpeed.cc.
+ *
+ * To match the MWCJump.res output, temporarily change the constants
+ * in MWC64k2a2.java to:
+ *   A1 = 0x07b88c6ac008d039L;  // 556348944096481337
+ *   A2 = 0x001d4f74ad35355fL;  // 8250136865355103
+ ** in MWC64k3a2.java to:
+ *A2 = 0x320fbe97bef0f95L, A3 = 0x4a1849ec18bfa6L; 
+ */
+    
+   private static void runJumpTest(StringBuilder out) {
+	   out.append("");
+	   out.append("============================================================= \n");
+	   out.append("MWC64k2a2 jump test \\n");
+	   out.append("jumpSize = " + JUMP_SIZE +"\n");
+	   out.append("n jumps for timing = " + N_JUMPS +"\n");
+
+      MWC64k2a2 rng = new MWC64k2a2();
+      rng.setSeed(SEED);
+
+      out.append("");
+      out.append("Successive jumps ahead: \\n");
+      out.append("initial state = " + state(rng.getState()) + "\n");
+
+      long start = System.nanoTime();
+
+      for (int i = 1; i <= 4; i++) {
+         rng.advanceStateByJump(JUMP_SIZE);
+         out.append("after jump " + i + " = " + state(rng.getState()) + "\n");
+      }
+
+      long end = System.nanoTime();
+
+      out.append("time for 4 jumps = " + seconds(start, end) + "\n");
+
+      /*
+       * One big jump from the original seed.
+       * This corresponds to jumpSize2 = n0 * jumpSize = 4 * 5000 = 20000.
+       */
+//      MWC64k2a2 bigJump = new MWC64k2a2();
+//      bigJump.setSeed(SEED);
+      rng.setSeed(SEED);
+
+      start = System.nanoTime();
+
+      rng.advanceStateByJump(4L * JUMP_SIZE);
+
+      end = System.nanoTime();
+
+      out.append("\n");
+      out.append("One large jump: \n");
+      out.append("jumpSize2 = " + (4L * JUMP_SIZE) + "\n");
+      out.append("state = " + state(rng.getState())+"\n");
+      out.append("time = " + seconds(start, end) + "\n");
+
+      /*
+       * Timing test:
+       * jump ahead by jumpSize, repeated N_JUMPS times.
+       */
+//      MWC64k2a2 manyJumps = new MWC64k2a2();
+//      manyJumps.setSeed(SEED);
+      rng.setSeed(SEED);
+
+      start = System.nanoTime();
+
+      for (long i = 0; i < N_JUMPS; i++) {
+    	  rng.advanceStateByJump(JUMP_SIZE);
+      }
+
+      end = System.nanoTime();
+
+      out.append("\n");
+      out.append("Repeated jump timing:\n");
+      out.append("number of jumps = " + N_JUMPS +"\n");
+      out.append("jumpSize = " + JUMP_SIZE+"\n");
+      out.append("final state = " + state(rng.getState()) + "\n");
+      out.append("time = " + seconds(start, end) + "\n");
+   }
+
+   /*
+    * Print unsigned 64-bit state values.
+    */
+   private static String state(long[] s) {
+      return "[" +
+         Long.toUnsignedString(s[0]) + " " +
+         Long.toUnsignedString(s[1]) + " " +
+         Long.toUnsignedString(s[2]) +
+      "]";
+   }
+
+   private static double seconds(long start, long end) {
+      return (end - start) / 1.0e9;
+   }
+   
+
+}

--- a/src/main/docs/examples/rngexperiments/RngFixedJumpSpeed.java
+++ b/src/main/docs/examples/rngexperiments/RngFixedJumpSpeed.java
@@ -1,0 +1,252 @@
+package rngexperiments;
+
+import java.io.FileWriter;
+import java.io.IOException;
+
+import umontreal.ssj.rng.MRG32k3a;
+import umontreal.ssj.rng.MWC64k2a2;
+import umontreal.ssj.rng.MWC64k3a2;
+import umontreal.ssj.rng.LFSR258;
+import umontreal.ssj.rng.RandomStream;
+
+/**
+ * Speed test for fixed stream and substream jumps in several SSJ random streams.
+ *
+ * This class compares:
+ *
+ * 1. Stream jumps:
+ *    Creating a new stream object repeatedly. In SSJ, constructing a new stream
+ *    advances the package-level seed to the next stream.
+ *
+ * 2. Substream jumps:
+ *    Calling resetNextSubstream() repeatedly on an existing stream.
+ *
+ * Each generator is tested for N runs. Run 1 is treated as a warm-up run because
+ * the JIT compiler may not have optimized the code yet. Therefore, Run 1 is
+ * printed but excluded from the reported average. The average is computed only
+ * over runs 2 to N.
+ */
+public class RngFixedJumpSpeed {
+
+    /** Number of jumps performed in each run. */
+    static final int M = 1_000_000;
+
+    /** Number of runs. Run 1 is warm-up and is not included in the average. */
+    static final int N = 5;
+
+    /**
+     * Sink variable used to prevent the JVM from removing object creation
+     * as dead code in the stream-jump tests.
+     */
+    static RandomStream streamSink;
+
+    /**
+     * Runs the stream-jump and substream-jump speed tests.
+     */
+    public static void main(String[] args) throws IOException {
+        StringBuilder out = new StringBuilder();
+
+        out.append("Jump speed test\n");
+        out.append("M = ").append(M).append(" jumps per run\n");
+        out.append("N = ").append(N).append(" runs\n");
+        out.append("Run 1 is a warm-up run and is not included in the average.\n");
+        out.append("Average is computed over runs 2 to ").append(N).append(".\n\n");
+
+        testStreamJump(out);
+        testSubstreamJump(out);
+
+        System.out.println(out);
+
+//        FileWriter writer = new FileWriter("/home/otman/Documents/GitHub/Data/o-MWC-test/MRGJumpSpeedTest.res");
+//        writer.write(out.toString());
+//        writer.close();
+    }
+
+    /**
+     * Tests stream jumps by repeatedly creating new stream objects.
+     */
+    static void testStreamJump(StringBuilder out) {
+        out.append("===== Stream jump: new object =====\n\n");
+
+        runStreamJumpMRG32k3a(out);
+        runStreamJumpLFSR258(out);
+        runStreamJumpMWC64k2a2(out);
+        runStreamJumpMWC64k3a2(out);
+
+        out.append("\n");
+    }
+
+    /**
+     * Tests substream jumps by repeatedly calling resetNextSubstream().
+     */
+    static void testSubstreamJump(StringBuilder out) {
+        out.append("===== Substream jump: resetNextSubstream() =====\n\n");
+
+        runSubstreamJump("MRG32k3a", new MRG32k3a(), out);
+        runSubstreamJump("LFSR258", new LFSR258(), out);
+        runSubstreamJump("MWC64k2a2", new MWC64k2a2(), out);
+        runSubstreamJump("MWC64k3a2", new MWC64k3a2(), out);
+
+        out.append("\n");
+    }
+
+    /**
+     * Measures stream jumps for MRG32k3a by repeatedly creating new objects.
+     */
+    static void runStreamJumpMRG32k3a(StringBuilder out) {
+        out.append("MRG32k3a\n");
+
+        double total = 0.0;
+
+        for (int rep = 1; rep <= N; rep++) {
+            long start = System.nanoTime();
+
+            for (int i = 0; i < M; i++)
+                streamSink = new MRG32k3a();
+
+            double time = (System.nanoTime() - start) / 1_000_000.0;
+
+            if (rep > 1)
+                total += time;
+
+            out.append("Run ").append(rep).append(": ").append(time).append(" ms");
+
+            if (rep == 1)
+                out.append("  (warm-up, not included in average)");
+
+            out.append("\n");
+        }
+
+        out.append("Average over runs 2 to ").append(N).append(": ")
+           .append(total / (N - 1)).append(" ms\n\n");
+    }
+
+    /**
+     * Measures stream jumps for MWC64k2a2 by repeatedly creating new objects.
+     */
+    static void runStreamJumpMWC64k2a2(StringBuilder out) {
+        out.append("MWC64k2a2\n");
+
+        double total = 0.0;
+
+        for (int rep = 1; rep <= N; rep++) {
+            long start = System.nanoTime();
+
+            for (int i = 0; i < M; i++)
+                streamSink = new MWC64k2a2();
+
+            double time = (System.nanoTime() - start) / 1_000_000.0;
+
+            if (rep > 1)
+                total += time;
+
+            out.append("Run ").append(rep).append(": ").append(time).append(" ms");
+
+            if (rep == 1)
+                out.append("  (warm-up, not included in average)");
+
+            out.append("\n");
+        }
+
+        out.append("Average over runs 2 to ").append(N).append(": ")
+           .append(total / (N - 1)).append(" ms\n\n");
+    }
+
+    /**
+     * Measures stream jumps for MWC64k3a2 by repeatedly creating new objects.
+     */
+    static void runStreamJumpMWC64k3a2(StringBuilder out) {
+        out.append("MWC64k3a2\n");
+
+        double total = 0.0;
+
+        for (int rep = 1; rep <= N; rep++) {
+            long start = System.nanoTime();
+
+            for (int i = 0; i < M; i++)
+                streamSink = new MWC64k3a2();
+
+            double time = (System.nanoTime() - start) / 1_000_000.0;
+
+            if (rep > 1)
+                total += time;
+
+            out.append("Run ").append(rep).append(": ").append(time).append(" ms");
+
+            if (rep == 1)
+                out.append("  (warm-up, not included in average)");
+
+            out.append("\n");
+        }
+
+        out.append("Average over runs 2 to ").append(N).append(": ")
+           .append(total / (N - 1)).append(" ms\n\n");
+    }
+
+    /**
+     * Measures stream jumps for LFSR258 by repeatedly creating new objects.
+     */
+    static void runStreamJumpLFSR258(StringBuilder out) {
+        out.append("LFSR258\n");
+
+        double total = 0.0;
+
+        for (int rep = 1; rep <= N; rep++) {
+            long start = System.nanoTime();
+
+            for (int i = 0; i < M; i++)
+                streamSink = new LFSR258();
+
+            double time = (System.nanoTime() - start) / 1_000_000.0;
+
+            if (rep > 1)
+                total += time;
+
+            out.append("Run ").append(rep).append(": ").append(time).append(" ms");
+
+            if (rep == 1)
+                out.append("  (warm-up, not included in average)");
+
+            out.append("\n");
+        }
+
+        out.append("Average over runs 2 to ").append(N).append(": ")
+           .append(total / (N - 1)).append(" ms\n\n");
+    }
+
+    /**
+     * Measures substream jumps for a given RandomStream by repeatedly calling
+     * resetNextSubstream() on the same stream object.
+     *
+     * @param name generator name printed in the result file
+     * @param stream stream object used for the test
+     * @param out output buffer
+     */
+    static void runSubstreamJump(String name, RandomStream stream, StringBuilder out) {
+        out.append(name).append("\n");
+
+        double total = 0.0;
+
+        for (int rep = 1; rep <= N; rep++) {
+            long start = System.nanoTime();
+
+            for (int i = 0; i < M; i++)
+                stream.resetNextSubstream();
+
+            double time = (System.nanoTime() - start) / 1_000_000.0;
+
+            if (rep > 1)
+                total += time;
+
+            out.append("Run ").append(rep).append(": ").append(time).append(" ms");
+
+            if (rep == 1)
+                out.append("  (warm-up, not included in average)");
+
+            out.append("\n");
+        }
+
+        out.append("Average over runs 2 to ").append(N).append(": ")
+           .append(total / (N - 1)).append(" ms\n\n");
+    }
+}

--- a/src/main/docs/examples/rngexperiments/TestMWC64k3a2Jump.java
+++ b/src/main/docs/examples/rngexperiments/TestMWC64k3a2Jump.java
@@ -1,0 +1,302 @@
+package rngexperiments;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+
+import umontreal.ssj.rng.MWC64k3a2;
+
+/**
+ * Tests the jump implementation of MWC64k3a2.
+ *
+ * The test checks three things:
+ *
+ * 1. A generic jump by n steps gives the same state as calling nextRaw() n times.
+ * 2. resetNextSubstream() gives the same state as a generic jump by 2^118.
+ * 3. Creating new streams gives the same states as generic jumps by 2^169.
+ *
+ *testSubstreamJump() and testStreamJump() assume that MWC64k3a2 has:
+ *
+ * public void advanceStateByJump(BigInteger n) // it has to be changed in the generator to run the test
+ *
+ * This is needed because the fixed jump sizes 2^118 and 2^169 are too large
+ * to fit in a Java long.
+ */
+public class TestMWC64k3a2Jump {
+
+   /** Stream spacing for MWC64k3a2: 2^169 generated values. */
+   private static final int STREAM_ADVANCE_EXPONENT = 169;
+
+   /** Substream spacing for MWC64k3a2: 2^118 generated values. */
+   private static final int SUBSTREAM_ADVANCE_EXPONENT = 118;
+
+   /** BigInteger value of the stream jump, equal to 2^169. */
+   private static final BigInteger STREAM_JUMP =
+         BigInteger.ONE.shiftLeft(STREAM_ADVANCE_EXPONENT);
+
+   /** BigInteger value of the substream jump, equal to 2^118. */
+   private static final BigInteger SUBSTREAM_JUMP =
+         BigInteger.ONE.shiftLeft(SUBSTREAM_ADVANCE_EXPONENT);
+
+   /**
+    * Test seeds.
+    *
+    * Each seed has the form:
+    *
+    * {x3, x2, x1, carry}
+    */
+   private static final long[][] SEEDS = {
+         {1L, 3L, 4L, 5L},
+         {12345L, 67890L, 13579L, 24680L},
+         {-1L, 1L, 2L, 3L},
+         {Long.MIN_VALUE, Long.MAX_VALUE, -123456789L, 999999999999L},
+         {-1L, -1L, -1L, 184000000000000000L}
+   };
+
+   /**
+    * Small jump sizes.
+    *
+    * These are small enough to compare against repeated calls to nextRaw().
+    */
+   private static final int[] SMALL_JUMPS = {
+         0, 1, 2, 3, 4, 5, 10, 63, 64, 65, 100, 1000, 10000
+   };
+
+   /** Number of successful comparisons. */
+   private static int good = 0;
+
+   /** Number of failed comparisons. */
+   private static int bad = 0;
+
+   /**
+    * Runs all jump tests and prints a final summary.
+    */
+   public static void main(String[] args) {
+      testJumpAgainstGeneration();
+//      testSubstreamJump();// needs big integer as params of advanceStateByJump
+//      testStreamJump(); // needs big integer as params of advanceStateByJump
+
+      System.out.println();
+      System.out.println("======================================");
+      System.out.println("SUMMARY");
+      System.out.println("GOOD tests = " + good);
+      System.out.println("BAD tests  = " + bad);
+      System.out.println("======================================");
+   }
+
+   /**
+    * Tests that advanceStateByJump(n) gives the same state as generating n values.
+    *
+    * This test is only done for small n, because repeated generation is not possible
+    * for large fixed jumps like 2^118 or 2^169.
+    */
+   private static void testJumpAgainstGeneration() {
+      System.out.println();
+      System.out.println("======================================");
+      System.out.println("TEST 1: jump(n) vs n calls to nextRaw()");
+      System.out.println("======================================");
+
+      for (long[] seed : SEEDS) {
+         for (int n : SMALL_JUMPS) {
+            MWC64k3a2 byGeneration = new MWC64k3a2();
+            byGeneration.setSeed(seed.clone());
+
+            MWC64k3a2 byJump = new MWC64k3a2();
+            byJump.setSeed(seed.clone());
+
+            long[] start = seed.clone();
+
+            // Reference path: advance the state by generating n raw values.
+            for (int i = 0; i < n; i++)
+               byGeneration.nextRaw();
+
+            // Jump path: advance the state directly by n steps.
+            byJump.advanceStateByJump(n); // must be updated if advanceStateByJump takes BigInteger
+
+            long[] expected = byGeneration.getState();
+            long[] actual = byJump.getState();
+
+            boolean sameState = Arrays.equals(expected, actual);
+
+            // Extra check: after both states match, the next output should match too.
+            long nextExpected = byGeneration.nextRaw();
+            long nextActual = byJump.nextRaw();
+
+            boolean sameNext = (nextExpected == nextActual);
+            boolean ok = sameState && sameNext;
+
+            printResult(
+                  "jump(" + n + ") vs " + n + " nextRaw()",
+                  start,
+                  expected,
+                  actual,
+                  ok
+            );
+
+            System.out.println("next after expected = " + Long.toUnsignedString(nextExpected));
+            System.out.println("next after actual   = " + Long.toUnsignedString(nextActual));
+            System.out.println("next output match   = " + sameNext);
+            System.out.println();
+         }
+      }
+   }
+
+   /**
+    * Tests that resetNextSubstream() gives the same result as a generic jump by 2^118.
+    *
+    * This checks that the hardcoded/precomputed substream jump constants are correct.
+    */
+  /* private static void testSubstreamJump() {
+      System.out.println();
+      System.out.println("======================================");
+      System.out.println("TEST 2: resetNextSubstream() vs jump(2^" + SUBSTREAM_ADVANCE_EXPONENT + ")");
+      System.out.println("======================================");
+
+      for (long[] seed : SEEDS) {
+         MWC64k3a2 fixed = new MWC64k3a2();
+         fixed.setSeed(seed.clone());
+
+         MWC64k3a2 generic = new MWC64k3a2();
+         generic.setSeed(seed.clone());
+
+         long[] start = seed.clone();
+
+         // Fixed path: use the generator's precomputed substream jump.
+         fixed.resetNextSubstream();
+
+         // Reference path: use the generic BigInteger jump by 2^118.
+         generic.advanceStateByJump(SUBSTREAM_JUMP); // change long n to BigInteger n and n to v in MWC64k3a2 to run this method
+
+         long[] fixedState = fixed.getState();
+         long[] genericState = generic.getState();
+
+         printResult(
+               "first substream jump",
+               start,
+               genericState,
+               fixedState,
+               Arrays.equals(genericState, fixedState)
+         );
+
+         // Repeat once to check that consecutive substream jumps also match.
+         fixed.resetNextSubstream();
+         generic.advanceStateByJump(SUBSTREAM_JUMP); // change long n to BigInteger n and n to v in MWC64k3a2 to run this method
+
+         long[] fixedState2 = fixed.getState();
+         long[] genericState2 = generic.getState();
+
+         printResult(
+               "second substream jump",
+               fixedState,
+               genericState2,
+               fixedState2,
+               Arrays.equals(genericState2, fixedState2)
+         );
+      }
+   }
+*/
+   /**
+    * Tests that stream creation advances the package seed by 2^169 each time.
+    *
+    * This checks that the fixed stream jump used in the constructor is correct.
+    */
+   /*private static void testStreamJump() {
+      System.out.println();
+      System.out.println("======================================");
+      System.out.println("TEST 3: stream creation vs jump(2^" + STREAM_ADVANCE_EXPONENT + ")");
+      System.out.println("======================================");
+
+      for (long[] seed : SEEDS) {
+         // Set the package seed so the next created stream starts from this seed.
+         MWC64k3a2.setPackageSeed(seed.clone());
+
+         // The constructor should create streams separated by the stream jump.
+         MWC64k3a2 stream1 = new MWC64k3a2();
+         MWC64k3a2 stream2 = new MWC64k3a2();
+         MWC64k3a2 stream3 = new MWC64k3a2();
+
+         long[] stream1State = stream1.getState();
+         long[] stream2State = stream2.getState();
+         long[] stream3State = stream3.getState();
+
+         boolean firstOk = Arrays.equals(seed, stream1State);
+
+         printResult(
+               "first stream starts at package seed",
+               seed,
+               seed,
+               stream1State,
+               firstOk
+         );
+
+         MWC64k3a2 expected2 = new MWC64k3a2();
+         expected2.setSeed(seed.clone());
+
+         // Expected second stream = initial seed advanced by one stream jump.
+         expected2.advanceStateByJump(STREAM_JUMP); // change long n to BigInteger n and n to v in MWC64k3a2 to run this method
+
+         printResult(
+               "second stream vs jump(2^" + STREAM_ADVANCE_EXPONENT + ")",
+               seed,
+               expected2.getState(),
+               stream2State,
+               Arrays.equals(expected2.getState(), stream2State)
+         );
+
+         MWC64k3a2 expected3 = new MWC64k3a2();
+         expected3.setSeed(seed.clone());
+
+         // Expected third stream = initial seed advanced by two stream jumps.
+         expected3.advanceStateByJump(STREAM_JUMP.multiply(BigInteger.valueOf(2L))); // change long n to BigInteger n and n to v in MWC64k3a2 to run this method
+
+         printResult(
+               "third stream vs jump(2 * 2^" + STREAM_ADVANCE_EXPONENT + ")",
+               seed,
+               expected3.getState(),
+               stream3State,
+               Arrays.equals(expected3.getState(), stream3State)
+         );
+      }
+   }*/
+
+   /**
+    * Prints one comparison result and updates the GOOD/BAD counters.
+    *
+    * @param label description of the test
+    * @param start starting state
+    * @param expected reference state
+    * @param actual tested state
+    * @param ok true if expected and actual match
+    */
+   private static void printResult(String label, long[] start, long[] expected, long[] actual, boolean ok) {
+      System.out.println("--------------------------------------");
+      System.out.println(label);
+      System.out.println("start    = " + stateToString(start));
+      System.out.println("expected = " + stateToString(expected));
+      System.out.println("actual   = " + stateToString(actual));
+      System.out.println("result   = " + (ok ? "GOOD" : "BAD"));
+
+      if (ok)
+         good++;
+      else
+         bad++;
+   }
+
+   /**
+    * Converts a state array to a readable unsigned string.
+    *
+    * @param state state array
+    * @return string representation of the state
+    */
+   private static String stateToString(long[] state) {
+      StringBuilder sb = new StringBuilder("{ ");
+
+      for (int i = 0; i < state.length; i++) {
+         if (i > 0)
+            sb.append(", ");
+         sb.append(Long.toUnsignedString(state[i]));
+      }
+
+      sb.append(" }");
+      return sb.toString();
+   }
+}

--- a/src/main/docs/examples/rngexperiments/TestMWCSpeedHelpers.java
+++ b/src/main/docs/examples/rngexperiments/TestMWCSpeedHelpers.java
@@ -1,0 +1,1392 @@
+package rngexperiments;
+
+import java.math.BigInteger;
+import java.util.function.LongSupplier;
+import java.io.PrintStream;
+import java.io.FileNotFoundException;
+
+
+/**
+* Java mirror of the C++ TestMWCSpeed.cc benchmark. The goal is to reproduce the same generator recurrences
+*  and benchmark structure as the C++ file.
+* Java does not provide uint64_t or __uint128_t, so unsigned 64-bit values are stored in long variables,
+*  and the simulated 128-bit product tau is represented by two 64-bit parts: tauHigh and tauLow.
+*
+* This version uses helper methods such as setTauMulAdd, setTauMulAdd2,
+* setTauMulAdd3, and setTauMul128Add to compute tau. The helpers store the
+* simulated 128-bit intermediate values in static temporary variables
+* tauLow, tauHigh, pLow, pHigh, oldLow, sum3Low, and sum3High.
+*
+* Findings from the Java speed tests:
+*
+* 1. For carry propagation, the branchless form : high += condition ? 1L : 0L; 
+*    was faster in these tests than  if (condition) high++;
+* This is why carry updates use the ternary-add form.
+*
+* 2. Generators that require more calls to Math.unsignedMultiplyHigh are
+* generally slower in Java, because Java must emulate the high 64 bits of
+* an unsigned 128-bit product.
+*
+* 3. Some Vigna coefficients are unsigned 64-bit constants larger than
+* Long.MAX_VALUE, for example constants starting with 0xff.... Java stores
+* these as negative long values. Passing such values directly to
+* Math.unsignedMultiplyHigh is slower, because the method must correct the
+* signed high product to obtain the unsigned high product.
+*
+* For these cases, this version uses a special helper based on
+* a = 2^64 - q  with q = -a in Java. It computes q*x and reconstructs
+* (2^64 - q)*x + carry by subtraction. This keeps the same recurrence while
+* avoiding the slower negative-coefficient path in Math.unsignedMultiplyHigh.
+*
+* This helper-based version is useful because it keeps the arithmetic logic
+* compact and close to the structure of a reusable implementation.
+* 
+* To write results to a .res file uncomment the PrintStream in main.
+ * */
+public final class TestMWCSpeedHelpers {
+    static long x, y, z, c; 
+    static long x1, x2, x3;
+
+    static long tauLow;//Low 64 bits of the simulated C++ __uint128_t variable tau.
+    static long pLow; //  Low halves of second and third products(a2x2; a3x3)
+    static long oldLow; // used as tmp to store taulow to see if it has overflowd after the addition: tauLow += carry;
+    
+    static long tauHigh;//High 64 bits of the simulated C++ __uint128_t variable tau.
+    static long pHigh;//high halves of second and third products(a2x2; a3x3)
+    
+    
+    static long sum3Low; // Low 64 bits of x1+x2 or x1+x2+x3 in equal-coefficient generators.
+    static long sum3High; //High carry of x1+x2 or x1+x2+x3 in equal-coefficient generators. 
+    static long sum;//Unsigned sum modulo 2^64 accumulated in integer speed tests. 
+
+    static long block53;//emporary 53-bit block used by U(0,1) generators that reject zero.
+    static long tmp; // for timing
+    static long tottmp; // total time
+
+    static final double twom53 = 0x1.0p-53; //1/2^53 equivalent to 1.0 / (double) ((uint64_t) 1 << 53) in c++
+    static final double twom55 = 0x1.0p-55;
+    static final double twom63 = 0x1.0p-63;
+    static final double twom64 = 0x1.0p-64;
+
+    private TestMWCSpeedHelpers() {}
+
+    // print an unit128 in decimal
+    static String uint128DecStr(long high, long low) {
+        BigInteger hi = new BigInteger(Long.toUnsignedString(high));
+        BigInteger lo = new BigInteger(Long.toUnsignedString(low));
+        return hi.shiftLeft(64).add(lo).toString();
+    }
+    // Called at the beginning of a speed test.
+    static void init() {
+        x1 = x2 = x3 = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+    }
+
+    static void printState() {
+        System.out.println("sum = " + Long.toUnsignedString(sum));
+        System.out.println("c   = " + Long.toUnsignedString(c));
+        System.out.println("tau   = " + uint128DecStr(tauHigh, tauLow));
+    }
+
+    static void printResults(String rngName, long elapsedNanos, long sum) {
+        System.out.printf("%16s%13.6f    %18s%n",
+                rngName, elapsedNanos / 1.0e9, Long.toUnsignedString(sum));
+    }
+
+    static void printResultsDouble(String rngName, long elapsedNanos, double average) {
+        System.out.printf("%16s%13.8f  %12.8f%n",
+                rngName, elapsedNanos / 1.0e9, average);
+    }
+
+/**
+ * Computes tau = a1*x1 as an unsigned 128-bit value.
+ * First stores a1*x1 in the global pair (tauHigh, tauLow).
+ * Then adds the carry to tauLow and
+ * updates tauHigh if the addition overflows tauLow.
+ */
+    static void setTauMulAdd(long a1, long x1Value, long carry) {
+        tauLow = a1 * x1Value;
+        tauHigh = Math.unsignedMultiplyHigh(a1, x1Value);
+        oldLow = tauLow;
+        tauLow += carry;
+        tauHigh += Long.compareUnsigned(tauLow, oldLow)  < 0 ? 1L : 0L;
+    }
+    
+    
+static void setTauNegMulAddFromA(long a, long xValue, long carry) {
+    // a is the original 0xff... coefficient.
+    // Since unsigned a = 2^64 - q, Java wraparound gives:
+    // q = -a
+    long q = -a;
+
+    // Compute q * xValue
+    pLow = q * xValue;
+    pHigh = Math.unsignedMultiplyHigh(q, xValue);
+
+    // Compute:
+    // tau = (2^64 - q) * xValue + carry
+    //     = xValue * 2^64 - q * xValue + carry
+    tauLow = carry - pLow;
+
+    long borrow = Long.compareUnsigned(carry, pLow) < 0 ? 1L : 0L;
+
+    tauHigh = xValue - pHigh - borrow;
+}
+
+    /**
+     * Computes tau = a1*x1 then p = a2*x2 , add p to tau, 
+     * Stores the result in the global pair (tauHigh, tauLow).
+     *  adds the carry and
+     *  updates tauHigh if any addition overflows .
+     */
+    static void setTauMulAdd2(long a1, long x1Value, long a2, long x2Value, long carry) {
+        tauLow = a1 * x1Value;
+        tauHigh = Math.unsignedMultiplyHigh(a1, x1Value);
+        pLow = a2 * x2Value;
+        pHigh = Math.unsignedMultiplyHigh(a2, x2Value);
+        // Previous low half, used to detect carry after adding pLow.
+        oldLow = tauLow;
+        tauLow += pLow;
+        tauHigh += pHigh + (Long.compareUnsigned(tauLow, oldLow) < 0 ? 1L : 0L);
+        oldLow = tauLow;
+        tauLow += carry;
+        tauHigh += Long.compareUnsigned(tauLow, oldLow) < 0 ? 1L : 0L;
+    }
+
+    /**
+     * Computes tau = a1*x1Value + a2*x2Value + a3*x3Value + carry
+     * as an unsigned 128-bit value. Stores the result in (tauHigh, tauLow), update tauhigh if additions overflow
+     */
+    static void setTauMulAdd3(long a1, long x1Value, long a2, long x2Value, long a3, long x3Value, long carry) {
+        tauLow = a1 * x1Value;
+        tauHigh = Math.unsignedMultiplyHigh(a1, x1Value);
+        
+        pLow = a2 * x2Value;
+        pHigh = Math.unsignedMultiplyHigh(a2, x2Value);
+        oldLow = tauLow;
+        tauLow += pLow;
+        tauHigh += pHigh + (Long.compareUnsigned(tauLow, oldLow) < 0 ? 1L : 0L);
+        
+        pLow = a3 * x3Value;
+        pHigh = Math.unsignedMultiplyHigh(a3, x3Value);
+        oldLow = tauLow;
+        tauLow += pLow;
+        tauHigh += pHigh + (Long.compareUnsigned(tauLow, oldLow) < 0 ? 1L : 0L);
+        
+        oldLow = tauLow;
+        tauLow += carry;
+        tauHigh +=  Long.compareUnsigned(tauLow, oldLow) < 0 ? 1L : 0L;
+    }
+
+
+    /**
+     * Computes tau = coefficient*(sumHigh*2^64 + sumLow) + carry.
+     * Used when equal coefficients require multiplying a 128-bit state sum.
+     */
+    static void setTauMul128Add(long coefficient, long sumLow, long sumHigh, long carry) {
+        tauLow = coefficient * sumLow;
+        tauHigh = Math.unsignedMultiplyHigh(coefficient, sumLow) + coefficient * sumHigh;
+        oldLow = tauLow;
+        tauLow += carry;
+        tauHigh +=  Long.compareUnsigned(tauLow, oldLow) < 0 ? 1L : 0L;
+    }
+
+    /**
+     * Returns the high 64 bits of tau - coefficient*stateValue.
+     * Used by general-a0 generators where the new carry is derived this way. See mwc64k2a..gk,
+     */
+    static long highOfTauMinusProduct(long coefficient, long stateValue) {
+        // Low and high halves of the unsigned 128-bit product being subtracted.
+        long pLow = coefficient * stateValue;
+        long pHigh = Math.unsignedMultiplyHigh(coefficient, stateValue);
+
+        // Borrow from the low half subtraction.
+        long borrow = Long.compareUnsigned(tauLow, pLow) < 0 ? 1L : 0L;
+        return tauHigh - pHigh - borrow;
+    }
+
+
+    /**
+     * Returns the high 64 bits of tau + coefficient*stateValue.
+     * Used by GMWC256 for its carry update.
+     */
+    static long highOfTauPlusProduct(long coefficient, long stateValue) {
+        // Low and high halves of the unsigned 128-bit product being added.
+        long pLow = coefficient * stateValue;
+        long pHigh = Math.unsignedMultiplyHigh(coefficient, stateValue);
+
+        // Low half of tau + product, used to detect carry.
+        long low = tauLow + pLow;
+        long carry = Long.compareUnsigned(low, tauLow) < 0 ? 1L : 0L;
+        return tauHigh + pHigh + carry;
+    }
+
+
+    /**
+     * Converts a Java long interpreted as unsigned uint64_t into a nonnegative double.
+     * Needed for full 64-bit scaling by 2^-64.
+     */
+    static double unsignedToDouble(long v) {
+        if (v >= 0L)
+            return (double) v;
+        return (double) (v & Long.MAX_VALUE) + 0x1.0p63;
+        
+    }
+
+    // *******   k = 1  ********************************************** 
+
+    // From Vigna 2021
+
+    static long MWC128() {
+        final long result = x;
+        //setTauMulAdd(0x87eac24b8adc9L, x, c);
+        setTauNegMulAddFromA(0xffebb71d94fcdaf9L, x, c); 
+        x = tauLow;
+        c = tauHigh;
+        return result;
+    }
+
+    // k = 1, a_0 = -1.
+    static long mwc64k1() {
+        x2 = x1;
+        setTauMulAdd(0x87eac24b8adc9L, x1, c);
+        c = tauHigh;
+        x1 = tauLow;
+        return x2;
+    }
+
+    // *******   k = 2  **********************************************
+
+    // From Vigna 2021. Here, a_0=-1 and a_1=0.
+
+    static long MWC192() {
+        final long result = y;
+        //setTauMulAdd(0x4b740f53265dL, x, c);
+        setTauNegMulAddFromA(0xffa04e67b3c95d86L, x, c);
+        x = y;
+        y = tauLow;
+        c = tauHigh;
+        return result;
+    }
+
+    // From MWC1k2-0-62.res Here, a_0=-1 and a_1=0.
+
+    static long mwc64k2a1() {
+        x3 = x1;
+        setTauMulAdd(0x4b740f53265dL, x2, c);
+        x2 = x1;
+        x1 = tauLow;
+        c = tauHigh;
+        return x3;
+    }
+
+    // From MWC1k2-62-58.res a_0=-1
+
+    static long mwc64k2a2() {
+        final long out = x1;
+        setTauMulAdd2(0x2ae390b92740f6dL, x1, 0x6fcce264fcc37L, x2, c);
+        x2 = x1;
+        x1 = tauLow;
+        c = tauHigh;
+        return out;
+    }
+
+    // From MWC1k2-62-58.res a_0=-1
+
+    /**
+     * Same recurrence as mwc64k2a2, but returns x1 xor x2 as the output.
+     */
+    static long mwc64k2a2Xor() {
+        final long out = x1 ^ x2;
+        setTauMulAdd2(0x2ae390b92740f6dL, x1, 0x6fcce264fcc37L, x2, c);
+        x2 = x1;
+        x1 = tauLow;
+        c = tauHigh;
+        return out;
+    }
+
+    // a_0=-1
+
+    /**
+     * k=2 MWC64 generator where the two coefficients are equal.
+     * Computes coefficient*(x1+x2)+c using a 128-bit state sum.
+     */
+    static long mwc64k2a2eq() {
+        final long out = x1;
+        sum3Low = x1 + x2;
+        sum3High = Long.compareUnsigned(sum3Low, x1) < 0 ? 1L : 0L; // get the high if overflow
+        setTauMul128Add(0xc45ec2462f86L, sum3Low, sum3High, c);// compute tau: taulow = coef * sumlow; tau high = coef * tauhigh + overflow of taulow
+        x2 = x1;
+        x1 = tauLow;
+        c = tauHigh;
+        return out;
+    }
+
+    /**
+     * The is the same, ....... i m keeping it to mirror c++ code and results?
+     */
+    static long mwc64k2a2eq2() {
+        final long out = x1;      
+        sum3Low = x1 + x2;
+        sum3High = Long.compareUnsigned(sum3Low, x1) < 0 ? 1L : 0L;
+        setTauMul128Add(0xc45ec2462f86L, sum3Low, sum3High, c);
+        x2 = x1;
+        x1 = tauLow;
+        c = tauHigh;
+        return out;
+    }
+
+    // From MWCa0k2-0-62-58.res a_0 general, a_1=0
+
+    static long mwc64k2a1gk() {
+        setTauMulAdd(0x6595a0b6737eL, x2, c);
+        x2 = x1;
+        x1 = 0xba1485699989776dL * tauLow;
+        c = highOfTauMinusProduct(0xe4e1b5e445c2a65L, x1);
+        return x2;
+    }
+
+    // From MWCa0k2-60-58.res a_0 general
+    static long mwc64k2a2gk() {
+        final long out = x1;
+        setTauMulAdd2(0x22ddf8545f51c3dL, x1, 0x3b4ba2cc0eb83d39L, x2, c);
+        x2 = x1;
+        x1 = 0x5a9b2e257b3e1d95L * tauLow;
+        c = highOfTauMinusProduct(0x0f0cdf98a7bf45bdL, x1);
+        return out;
+    }
+
+    // *******   k = 3  *********************************************
+
+    // From Vigna 2021. a_0=-1, a_1 = a_2 = 0.
+
+    /**
+     * Vigna 2021 MWC256 raw generator. Returns z and advances (x,y,z,c).
+     */
+    static long MWC256() {
+        final long result = z;
+       // setTauMulAdd(0x14fabef33841dL, x, c);
+       setTauNegMulAddFromA(0xfff62cf2ccc0cdafL, x, c); ///
+        x = y;
+        y = z;
+        z = tauLow;
+        c = tauHigh;
+        return result;
+    }
+
+    // From MWC1k3-00-62.res a_0 = -1, a_1 = a_2 = 0.
+
+    /**0x14fabef33841dL
+     * k=3 MWC64 generator with a0=-1 and only the last coefficient nonzero.
+     */
+    static long mwc64k3a1() {
+        final long out = x1;
+        setTauMulAdd(0x14fabef33841dL, x3, c);
+        x3 = x2;
+        x2 = x1;
+        x1 = tauLow;
+        c = tauHigh;
+        return out;
+    }
+
+    // From MWC1k3-0-60-58.res a_0 = -1, a_1 = 0.
+
+    /**
+     * k=3 MWC64 generator with a0=-1 and two nonzero coefficients.
+     */
+    static long mwc64k3a2() {
+        final long out = x1;
+        setTauMulAdd2(0x2902ebc31ec3683L, x2, 0x57baa090037L, x3, c);
+        x3 = x2;
+        x2 = x1;
+        x1 = tauLow;
+        c = tauHigh;
+        return out;
+    }
+
+    // From MWC1k3-60-58.res a_0 = -1.
+
+    /**
+     * k=3 MWC64 generator with a0=-1 and three nonzero coefficients.
+     */
+    static long mwc64k3a3() {
+        final long out = x1;
+        setTauMulAdd3(0x979f3660cbaca4L, x1, 0x31dcb74b96510a8L, x2,
+                0x5194d4649dcdL, x3, c);
+        x3 = x2;
+        x2 = x1;
+        x1 = tauLow;
+        c = tauHigh;
+        return out;
+    }
+
+    // Two coefficients are equal. a_0 =-1, a_2 = a_3.
+
+    /**
+     * k=3 generator with two equal coefficients on x2 and x3.
+     */
+    static long mwc64k3a2eq() {
+        final long out = x1;
+        sum3Low = x2 + x3;
+        sum3High = Long.compareUnsigned(sum3Low, x2) < 0 ? 1L : 0L;
+        setTauMul128Add(0x1d0710107d5dL, sum3Low, sum3High, c);
+        x3 = x2;
+        x2 = x1;
+        x1 = tauLow;
+        c = tauHigh;
+        return out;
+    }
+
+    // Three coefficients are equal. a_0 =-1, a_1 = a_2 = a_3.
+
+    /**
+     * k=3 generator with three equal coefficients on x1, x2, and x3.
+     */
+    static long mwc64k3a3eq() {
+        final long out = x1;
+        // Low half of x1+x2+x3.
+        long t = x1 + x2;
+
+        // High carry of the 128-bit sum x1+x2+x3.
+        long h = Long.compareUnsigned(t, x1) < 0 ? 1L : 0L;
+
+        // Previous low half, used to detect carry when adding x3.
+        long old = t;
+        t += x3;
+        h += Long.compareUnsigned(t, old) < 0 ? 1L : 0L;
+        sum3Low = t;
+        sum3High = h;
+        setTauMul128Add(0x1d495210185cL, sum3Low, sum3High, c);
+        x3 = x2;
+        x2 = x1;
+        x1 = tauLow;
+        c = tauHigh;
+        return out;
+    }
+
+    // From MWC1k3-0-60-58.res a_0 = -1, a_1 = a_2 = 0.
+
+    /**
+     * Same recurrence as mwc64k3a1, but returns x1 xor x3.
+     */
+    static long mwc64k3a1Xor() {
+        final long out = x1 ^ x3;
+        setTauMulAdd(0x14fabef33841dL, x3, c);
+        x3 = x2;
+        x2 = x1;
+        x1 = tauLow;
+        c = tauHigh;
+        return out;
+    }
+
+    // From MWC1k3-0-60-58.res a_0 = -1, a_1 = 0.
+
+    /**
+     * Same recurrence as mwc64k3a2, but returns x1 xor x3.
+     */
+    static long mwc64k3a2Xor() {
+        final long out = x1 ^ x3;
+        setTauMulAdd2(0x2902ebc31ec3683L, x2, 0x57baa090037L, x3, c);
+        x3 = x2;
+        x2 = x1;
+        x1 = tauLow;
+        c = tauHigh;
+        return out;
+    }
+
+    // From MWC1k3-60-58.res a_0 = -1.
+
+    /**
+     * Same recurrence as mwc64k3a3, but returns x1 xor x2.
+     */
+    static long mwc64k3a3Xor() {
+        final long out = x1 ^ x2;
+        setTauMulAdd3(0x979f3660cbaca4L, x1, 0x31dcb74b96510a8L, x2,
+                0x5194d4649dcdL, x3, c);
+        x3 = x2;
+        x2 = x1;
+        x1 = tauLow;
+        c = tauHigh;
+        return out;
+    }
+
+    // This version never returns 0, uses a while
+
+    /**
+     * Nonzero-output version of mwc64k3a2 using a while loop to reject zero.
+     */
+    static long mwc64k3a2No0w() {
+        long out = mwc64k3a2();
+        while (out == 0L)
+            out = mwc64k3a2();
+        return out;
+    }
+
+    // This version never returns 0, uses a if.
+
+    /**
+     * Nonzero-output version of mwc64k3a2 using recursive retry on zero.
+     */
+    static long mwc64k3a2No0i() {
+        long out = mwc64k3a2();
+        if (out == 0L) out = mwc64k3a2No0i();
+        return out;
+    }
+
+    // This version never returns 0
+
+    /**
+     * Nonzero-output version of mwc64k3a2 using an extra draw added on zero.
+     */
+    static long mwc64k3a2No0a() {
+        long out = mwc64k3a2();
+        if (out == 0L) out += mwc64k3a2();
+        return out;
+    }
+
+    // This version never returns 0, uses while.
+
+    static long mwc64k3a3No0w() {
+        long out = mwc64k3a3();
+        while (out == 0L)
+            out = mwc64k3a3();
+        return out;
+    }
+
+    // This version never returns 0.
+
+    /**
+     * Nonzero-output version of mwc64k3a3 using recursive retry on zero.
+     */
+    static long mwc64k3a3No0i() {
+        long out = mwc64k3a3();
+        if (out == 0L) out = mwc64k3a3No0i();
+        return out;
+    }
+
+    // This version never returns 0.
+    static long mwc64k3a3No0a() {
+        long out = mwc64k3a3();
+        if (out == 0L) out += mwc64k3a3();
+        return out;
+    }
+
+    // Parameters from Vigna 2021.
+    static final long GMWC_MINUSA0 = 0x54c3da46afb70fL;
+    static final long GMWC_A0INV = 0xbbf397e9a69da811L;
+    static final long GMWC_A3 = 0xff963a86efd088a2L;
+    
+    //static final long GMWC_MINUSA0 = 0xf53334560dL;
+    //static final long GMWC_A0INV = 0xa55ad7c337410603L;
+    //static final long GMWC_A3 = 0x02ce8eef308854abL;
+
+    // From Vigna 2021. a_0 general, a_1 = a_2 = 0.
+    static long GMWC256() {
+        setTauNegMulAddFromA(GMWC_A3, x, c);
+        x = y;
+        y = z;
+        z = GMWC_A0INV * tauLow;
+        c = highOfTauPlusProduct(GMWC_MINUSA0, z);
+        return z;
+    }
+
+    // From MWCa0k3-00-62.res a_0 general, a_1 = a_2 = 0.
+
+    static long mwc64k3a1gk() {
+        final long out = x1;
+        setTauMulAdd(0xf53334560dL, x3, c);
+        x3 = x2;
+        x2 = x1;
+        x1 = 0xa55ad7c337410603L * tauLow;
+        c = highOfTauMinusProduct(0x02ce8eef308854abL, x1);
+        return out;
+    }
+
+    // From MWCa0k3-0-60-58.res a_0 general, a_1 = 0.
+    static long mwc64k3a2gk() {
+        final long out = x1;
+        setTauMulAdd2(0x1a43e76662f692cL, x2, 0x5a888e5764193L, x3, c);
+        x3 = x2;
+        x2 = x1;
+        x1 = 0x9772ec11e3b050c5L * tauLow;
+        c = highOfTauMinusProduct(0x0e6f81c49aeeae0dL, x1);
+        return out;
+    }
+
+    // From MWCa0k3-60-58.res a_0 general.
+
+    /**
+     * k=3 general-a0 MWC64 generator with three nonzero coefficients.
+     */
+    static long mwc64k3a3gk() {
+        final long out = x1;
+        setTauMulAdd3(0x1427e7f2aedfa9cL, x1, 0x373ad6944cfb8d0L, x2,
+                0x0f2125fd7e3997L, x3, c);
+        x3 = x2;
+        x2 = x1;
+        x1 = 0xdd3034dd040dab6bL * tauLow;
+        c = highOfTauMinusProduct(0x0ea08673f5e82943L, x1);
+        return out;
+    }
+
+    // ****************************************************************
+    // U(0,1) generators
+
+    // This version may return 0
+    static double mwc64k2a2U01() {
+        return (mwc64k2a2() >>> 11) * twom53;
+    }
+
+    // This version never returns 0, uses a while
+    static double mwc64k2a2U01w() {
+        block53 = mwc64k2a2() >>> 11;
+        while (block53 == 0L)
+            block53 = mwc64k2a2() >>> 11;
+        return block53 * twom53;
+    }
+
+    // This version never returns 0, uses a if.
+
+    static double mwc64k2a2U01i() {
+        block53 = mwc64k2a2() >>> 11;
+        if (block53 == 0L) return mwc64k2a2U01i();
+        return block53 * twom53;
+    }
+
+
+    /**
+     * May return zero.
+     */
+    static double mwc64k2a2XorU01() {
+        return (mwc64k2a2Xor() >>> 11) * twom53;
+    }
+
+    // This version never returns 0, uses a if.
+
+    static double mwc64k2a2XorU01i() {
+        block53 = mwc64k2a2Xor() >>> 11;
+        if (block53 == 0L) return mwc64k2a2XorU01i();
+        return block53 * twom53;
+    }
+
+    // This version may return 0
+
+    static double mwc64k3a1U01() {
+        return (mwc64k3a1() >>> 11) * twom53;
+    }
+
+    // This version never returns 0, uses a while
+
+    static double mwc64k3a1U01w() {
+        block53 = mwc64k3a1() >>> 11;
+        while (block53 == 0L)
+            block53 = mwc64k3a1() >>> 11;
+        return block53 * twom53;
+    }
+
+    // This version never returns 0, uses a if.
+
+    static double mwc64k3a1U01i() {
+        block53 = mwc64k3a1() >>> 11;
+        if (block53 == 0L) return mwc64k3a1U01i();
+        return block53 * twom53;
+    }
+
+
+    /**
+     * Converts mwc64k3a1Xor output to U(0,1) using the top 53 bits. May return zero.
+     */
+    static double mwc64k3a1XorU01() {
+        return (mwc64k3a1Xor() >>> 11) * twom53;
+    }
+
+    // This version never returns 0, uses a if.
+
+    static double mwc64k3a1XorU01i() {
+        block53 = mwc64k3a1Xor() >>> 11;
+        if (block53 == 0L) return mwc64k3a1XorU01i();
+        return block53 * twom53;
+    }
+
+    // This version may return 0
+
+    static double mwc64k3a2U01() {
+        return (mwc64k3a2() >>> 11) * twom53;
+    }
+
+    // This version never returns 0, uses a while
+
+    static double mwc64k3a2U01w() {
+        block53 = mwc64k3a2() >>> 11;
+        while (block53 == 0L)
+            block53 = mwc64k3a2() >>> 11;
+        return block53 * twom53;
+    }
+
+    // This version never returns 0, uses a if.
+
+    static double mwc64k3a2U01i() {
+        block53 = mwc64k3a2() >>> 11;
+        if (block53 == 0L) return mwc64k3a2U01i();
+        return block53 * twom53;
+    }
+
+
+    /**
+     * Converts mwc64k3a2Xor output to U(0,1) using the top 53 bits. May return zero.
+     */
+    static double mwc64k3a2XorU01() {
+        return (mwc64k3a2Xor() >>> 11) * twom53;
+    }
+
+    // This version never returns 0, uses a if.
+
+    static double mwc64k3a2XorU01i() {
+        block53 = mwc64k3a2Xor() >>> 11;
+        if (block53 == 0L) return mwc64k3a2XorU01i();
+        return block53 * twom53;
+    }
+
+    // This version never returns 0, uses a while
+
+    static double mwc64k3a3U01w() {
+        block53 = mwc64k3a3() >>> 11;
+        while (block53 == 0L)
+            block53 = mwc64k3a3() >>> 11;
+        return block53 * twom53;
+    }
+
+    // This version never returns 0, uses a if.
+
+    static double mwc64k3a3U01i() {
+        block53 = mwc64k3a3() >>> 11;
+        if (block53 == 0L) return mwc64k3a3U01i();
+        return block53 * twom53;
+    }
+
+    // *************************************************************************
+
+
+    /**
+     * Runs a benchmark where the generator is passed as a LongSupplier.
+     * This intentionally measures the extra cost of indirect calls.
+     */
+    static void testLoop(String rngName, LongSupplier func, long n) {
+        x = y = z = x1 = x2 = x3 = c = 12345L;
+        sum = 0L;
+        long tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += func.getAsLong();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults(rngName, tmp, sum);
+    }
+
+    // *************************************************************************
+
+
+    /**
+     * Runs the same sections as the cc file.
+     */
+    public static void main(String[] args) throws FileNotFoundException {
+    	
+//    	PrintStream out = new PrintStream("C:/Users/cherrato/Documents/GitHub/Data/o-MWC-test/MWCSpeed10JavUdpVigNoIf.res");
+//    	System.setOut(out); // to write to res file uncomment these two lines
+    	
+         //long n = 4;
+         //long n = 1000L * 1000L; // One million
+        //long n = 1000L * 1000L * 1000L; // Number of generated values per benchmark: one billion
+         long n = 1000L * 1000L * 10000L; // Ten billions
+        System.out.println("\n=========JAVA========updated helper for vigna + never use if inside generetors ==========");
+        System.out.printf("Time to generate n = %d = %.6e numbers.%n", n, (double) n);
+        System.out.println("    Generator     Time (seconds)      Sum mod 2^{64} ");
+        tottmp = System.nanoTime();
+
+        // *******   k = 1  *********************************************
+        System.out.println("k = 1 ");
+
+        testLoop("MWC128 given as a parameter to testLoop    ", TestMWCSpeedHelpers::MWC128, n);
+        testLoop("mwc64k1 given as a parameter to testLoop   ", TestMWCSpeedHelpers::mwc64k1, n);
+        testLoop("mwc64k3a2 given as a parameter to testLoop ", TestMWCSpeedHelpers::mwc64k3a2, n);
+        System.out.println();
+
+        x = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += MWC128();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("MWC128", tmp, sum);
+
+        x1 = x2 = x3 = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += mwc64k1();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("mwc64k1", tmp, sum);
+
+
+        // *******   k = 2  *********************************************
+        System.out.println("k = 2 ");
+
+        x = y = z = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += MWC192();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("MWC192", tmp, sum);
+
+        x1 = x2 = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += mwc64k2a1();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("mwc64k2a1", tmp, sum);
+
+        x1 = x2 = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += mwc64k2a2();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("mwc64k2a2", tmp, sum);
+
+        x1 = x2 = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += mwc64k2a2eq();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("mwc64k2a2eq", tmp, sum);
+
+        x1 = x2 = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += mwc64k2a2eq2();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("mwc64k2a2eq2", tmp, sum);
+
+        x1 = x2 = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += mwc64k2a1gk();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("mwc64k2a1gk", tmp, sum);
+
+        x1 = x2 = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += mwc64k2a2gk();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("mwc64k2a2gk", tmp, sum);
+
+        // *******   k = 3  *********************************************
+        System.out.println("k = 3 ");
+
+        x = y = z = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += MWC256();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("MWC256", tmp, sum);
+
+        x1 = x2 = x3 = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += mwc64k3a1();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("mwc64k3a1", tmp, sum);
+
+        x1 = x2 = x3 = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += mwc64k3a2();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("mwc64k3a2", tmp, sum);
+
+        x1 = x2 = x3 = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += mwc64k3a3();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("mwc64k3a3", tmp, sum);
+
+        x1 = x2 = x3 = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += mwc64k3a2eq();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("mwc64k3a2eq", tmp, sum);
+
+        x1 = x2 = x3 = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += mwc64k3a3eq();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("mwc64k3a3eq", tmp, sum);
+
+        x1 = x2 = x3 = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += mwc64k3a1Xor();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("mwc64k3a1Xor", tmp, sum);
+
+        x1 = x2 = x3 = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += mwc64k3a2Xor();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("mwc64k3a2Xor", tmp, sum);
+
+        x1 = x2 = x3 = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += mwc64k3a3Xor();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("mwc64k3a3Xor", tmp, sum);
+        System.out.println();
+
+        // ************************************************************
+        // a_0 < -1
+
+        x = y = z = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += GMWC256();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("GMWC256", tmp, sum);
+
+        x1 = x2 = x3 = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += mwc64k3a1gk();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("mwc64k3a1gk", tmp, sum);
+
+        x1 = x2 = x3 = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += mwc64k3a2gk();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("mwc64k3a2gk", tmp, sum);
+
+        x1 = x2 = x3 = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += mwc64k3a3gk();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("mwc64k3a3gk", tmp, sum);
+
+        // ******************************************************
+        System.out.println("\nUniform over (0,1) ");
+        System.out.printf("standard dev. for average = (4n)^{-1/2} =    %.8f%n",
+                1.0 / Math.sqrt(2.0 * n));
+        System.out.println("      Generator              Time (seconds)    Average ");
+        double dsum = 0.0; // Accumulated sum of U(0,1) values for average tests
+
+        // k = 2
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += mwc64k2a2U01();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k2a2U01    53           ", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += (mwc64k2a2() >>> 1) * twom63;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k2a2 U(0,1) 63          ", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += (mwc64k2a2() >>> 11) * twom53 + twom55;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k2a2 U(0,1) 53, + twom55", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += mwc64k2a2U01i();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k2a2U01i U(0,1) 53      ", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += mwc64k2a2XorU01();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k2a2XorU01 U(0,1) 53    ", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += mwc64k2a2XorU01i();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k2a2XorU01i U(0,1) 53   ", tmp, dsum / n);
+
+        System.out.println();
+
+        // k = 3
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += (mwc64k3a1() >>> 11) * twom53;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a1 U(0,1) 53          ", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += mwc64k3a1U01();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a1U01 U(0,1) 53       ", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += mwc64k3a1U01w();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a1U01w U(0,1) 53      ", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += mwc64k3a1U01i();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a1U01i U(0,1) 53      ", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += mwc64k3a1XorU01();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a1XorU01 U(0,1) 53    ", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += mwc64k3a1XorU01i();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a1XorU01i U(0,1) 53   ", tmp, dsum / n);
+
+        System.out.println();
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += (mwc64k3a2() >>> 11) * twom53;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a2 U(0,1) 53          ", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += mwc64k3a2U01();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a2U01 U(0,1) 53       ", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += mwc64k3a2U01w();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a2U01w U(0,1) 53      ", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += mwc64k3a2U01i();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a2U01i U(0,1) 53      ", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += mwc64k3a2XorU01();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a2XorU01 U(0,1) 53    ", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += mwc64k3a2XorU01i();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a2XorU01i U(0,1) 53   ", tmp, dsum / n);
+
+        System.out.println();
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += (mwc64k3a3() >>> 11) * twom53;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a3 U(0,1) 53          ", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += mwc64k3a3U01w();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a3U01w U(0,1) 53      ", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += mwc64k3a3U01i();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a3U01i U(0,1) 53      ", tmp, dsum / n);
+
+        // ******************************************************************
+        // The following blocks mirror the C++ code that appears after
+        //     return 0;  // ******************************************************************
+        // in TestMWCSpeed.cc. They are included here because they are real test cases,
+        // even though they are unreachable in the original C++ file unless that return is removed.
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += unsignedToDouble(mwc64k2a2()) * twom64;
+        }
+        printResultsDouble("mwc64k2a2 U(0,1) 64", System.nanoTime() - tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += (mwc64k2a2Xor() >>> 11) * twom53;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k2a2Xor U(0,1) 53", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += (mwc64k2a2Xor() >>> 1) * twom63;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k2a2Xor U(0,1) 63", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += unsignedToDouble(mwc64k2a2Xor()) * twom64;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k2a2Xor U(0,1) 64", tmp, dsum / n);
+
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += (mwc64k3a1() >>> 11) * twom53;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a1 U(0,1) 53", tmp, dsum / n);
+
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += (mwc64k3a1() >>> 1) * twom63;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a1 U(0,1) 63", tmp, dsum / n);
+
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += unsignedToDouble(mwc64k3a1()) * twom64;
+        }
+        printResultsDouble("mwc64k3a1 U(0,1) 64", System.nanoTime() - tmp, dsum / n);
+
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += (mwc64k3a1Xor() >>> 11) * twom53;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a1Xor U(0,1)", tmp, dsum / n);
+
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += (mwc64k3a1Xor() >>> 1) * twom63;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a1Xor U(0,1) 63", tmp, dsum / n);
+
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += unsignedToDouble(mwc64k3a1Xor()) * twom64;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a1Xor U(0,1) 64", tmp, dsum / n);
+
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += (mwc64k3a2() >>> 11) * twom53;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a2 U(0,1)   ", tmp, dsum / n);
+
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += (mwc64k3a2() >>> 1) * twom63;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a2 U(0,1) 63", tmp, dsum / n);
+
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += unsignedToDouble(mwc64k3a2()) * twom64;
+        }
+        printResultsDouble("mwc64k3a2 U(0,1) 64", System.nanoTime() - tmp, dsum / n);
+
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += (mwc64k3a2Xor() >>> 11) * twom53;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a2Xor U(0,1) 53", tmp, dsum / n);
+
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += (mwc64k3a2Xor() >>> 1) * twom63;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a2Xor U(0,1) 63", tmp, dsum / n);
+
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += unsignedToDouble(mwc64k3a2Xor()) * twom64;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a2Xor U(0,1) 64", tmp, dsum / n);
+
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += (mwc64k3a3() >>> 11) * twom53;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a3 U(0,1) 53 ", tmp, dsum / n);
+
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += (mwc64k3a3() >>> 1) * twom63;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a3 U(0,1) 63 ", tmp, dsum / n);
+
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += unsignedToDouble(mwc64k3a3()) * twom64;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a3 U(0,1) 64 ", tmp, dsum / n);
+
+        System.out.println();
+
+        printResultsDouble("Total computing time: ", System.nanoTime() - tottmp, 0);
+    }
+}

--- a/src/main/docs/examples/rngexperiments/TestMWCSpeedLocalsNoHelpers.java
+++ b/src/main/docs/examples/rngexperiments/TestMWCSpeedLocalsNoHelpers.java
@@ -1,0 +1,1374 @@
+package rngexperiments;
+
+import java.util.function.LongSupplier;
+import java.io.PrintStream;
+import java.io.FileNotFoundException;
+
+/**
+* Java mirror of the C++ TestMWCSpeed.cc benchmark using local variables to represent simulated 128-bit intermediates.
+*
+* The goal is to reproduce the same generator recurrences and benchmark
+* structure as the C++ file, while making the Java hot loops closer to the C++
+* implementation. Java does not provide uint64_t or __uint128_t, so unsigned
+* 64-bit values are stored in long variables, and each simulated 128-bit
+* intermediate is represented locally by two 64-bit variables, usually tl/th
+* for tauLow/tauHigh and pl/ph for productLow/productHigh.
+*
+* Unlike TestMWCSpeed_2.java, this version does not use setTau... helper
+* methods in the hot generator methods. Generator state remains static
+* because it represents the actual state of the RNG, but arithmetic temporary
+* values are local variables inside each generator.
+*
+* This matters for speed comparisons. Static fields such as tauLow, tauHigh,
+* pLow, pHigh, oldLow, sum3Low, and sum3High are not part of the RNG state;
+* they are only temporary values. Keeping them local gives the JIT compiler a
+* better chance to keep them in registers and avoids passing intermediate
+* results through class-level fields.
+*
+* Findings from the Java speed tests:
+*
+* 1. For carry propagation, the branchless form     high += condition ? 1L : 0L;  was faster in these tests than  if (condition) high++;
+* 	This is why carry updates use the ternary-add form.
+*
+* 2. Generators that require more calls to Math.unsignedMultiplyHigh are
+* generally slower in Java, because Java must emulate the high 64 bits of
+* an unsigned 128-bit product.
+*
+* 3. Some Vigna coefficients are unsigned 64-bit constants larger than
+* Long.MAX_VALUE, for example constants starting with 0xff.... Java stores
+* these as negative long values. Passing such values directly to
+* Math.unsignedMultiplyHigh is slower, because the method must correct the
+* signed high product to obtain the unsigned high product.
+*
+* For these cases, this version inlines the same identity   a = 2^64 - q  with q = -a in Java. It computes q*x and reconstructs
+* (2^64 - q)*x + carry by subtraction. This keeps the same recurrence while
+* avoiding the slower negative-coefficient path in Math.unsignedMultiplyHigh.
+*
+* This local-variable version is mainly intended for speed comparison with
+* the helper-based Java version. It keeps the RNG state static, but keeps
+* the simulated 128-bit arithmetic intermediates as local high/low pairs
+* inside each generator, instead of storing them in static helper fields.
+*/
+
+public final class TestMWCSpeedLocalsNoHelpers {
+    static long x, y, z, c;
+    static long x1, x2, x3;
+    static long sum;
+    static long tmp;
+    static long tottmp;
+
+    static final double twom53 = 0x1.0p-53;
+    static final double twom55 = 0x1.0p-55;
+    static final double twom63 = 0x1.0p-63;
+    static final double twom64 = 0x1.0p-64;
+
+    static final long GMWC_MINUSA0 = 0x54c3da46afb70fL;
+    static final long GMWC_A0INV = 0xbbf397e9a69da811L;
+    static final long GMWC_A3 = 0xff963a86efd088a2L;
+
+    private TestMWCSpeedLocalsNoHelpers() {}
+
+    static void printResults(String rngName, long elapsedNanos, long sum) {
+        System.out.printf("%16s%13.6f    %18s%n",
+                rngName, elapsedNanos / 1.0e9, Long.toUnsignedString(sum));
+    }
+
+    static void printResultsDouble(String rngName, long elapsedNanos, double average) {
+        System.out.printf("%16s%13.8f  %12.8f%n",
+                rngName, elapsedNanos / 1.0e9, average);
+    }
+
+    static double unsignedToDouble(long v) {
+        if (v >= 0L)
+            return (double) v;
+        return (double) (v & Long.MAX_VALUE) + 0x1.0p63;
+    }
+
+    // *******   k = 1  **********************************************
+
+    // From Vigna 2021. Coefficient is 0xff..., so use a = 2^64 - q, q = -a.
+    static long MWC128() {
+        final long result = x;
+        final long q = -0xffebb71d94fcdaf9L;
+
+        long pl = q * x;
+        long ph = Math.unsignedMultiplyHigh(q, x);
+        long tl = c - pl;
+        long borrow = Long.compareUnsigned(c, pl) < 0 ? 1L : 0L;
+        long th = x - ph - borrow;
+
+        x = tl;
+        c = th;
+        return result;
+    }
+
+    // k = 1, a_0 = -1.
+    static long mwc64k1() {
+        final long out = x1;
+
+        long tl = 0x87eac24b8adc9L * x1;
+        long th = Math.unsignedMultiplyHigh(0x87eac24b8adc9L, x1);
+        long old = tl;
+        tl += c;
+        th += Long.compareUnsigned(tl, old) < 0 ? 1L : 0L;
+
+        x2 = out;
+        x1 = tl;
+        c = th;
+        return out;
+    }
+
+    // *******   k = 2  **********************************************
+
+    // From Vigna 2021. Coefficient is 0xff..., so use a = 2^64 - q, q = -a.
+    static long MWC192() {
+        final long result = y;
+        final long q = -0xffa04e67b3c95d86L;
+
+        long pl = q * x;
+        long ph = Math.unsignedMultiplyHigh(q, x);
+        long tl = c - pl;
+        long borrow = Long.compareUnsigned(c, pl) < 0 ? 1L : 0L;
+        long th = x - ph - borrow;
+
+        x = y;
+        y = tl;
+        c = th;
+        return result;
+    }
+
+    // From MWC1k2-0-62.res. Here, a_0=-1 and a_1=0.
+    static long mwc64k2a1() {
+        final long out = x1;
+
+        long tl = 0x4b740f53265dL * x2;
+        long th = Math.unsignedMultiplyHigh(0x4b740f53265dL, x2);
+        long old = tl;
+        tl += c;
+        th += Long.compareUnsigned(tl, old) < 0 ? 1L : 0L;
+
+        x3 = out;
+        x2 = out;
+        x1 = tl;
+        c = th;
+        return out;
+    }
+
+    // From MWC1k2-62-58.res. a_0=-1.
+    static long mwc64k2a2() {
+        final long out = x1;
+
+        long tl = 0x2ae390b92740f6dL * x1;
+        long th = Math.unsignedMultiplyHigh(0x2ae390b92740f6dL, x1);
+
+        long pl = 0x6fcce264fcc37L * x2;
+        long ph = Math.unsignedMultiplyHigh(0x6fcce264fcc37L, x2);
+        long old = tl;
+        tl += pl;
+        th += ph + (Long.compareUnsigned(tl, old) < 0 ? 1L : 0L);
+
+        old = tl;
+        tl += c;
+        th += Long.compareUnsigned(tl, old) < 0 ? 1L : 0L;
+
+        x2 = x1;
+        x1 = tl;
+        c = th;
+        return out;
+    }
+
+    // Same recurrence as mwc64k2a2, but returns x1 xor x2.
+    static long mwc64k2a2Xor() {
+        final long out = x1 ^ x2;
+
+        long tl = 0x2ae390b92740f6dL * x1;
+        long th = Math.unsignedMultiplyHigh(0x2ae390b92740f6dL, x1);
+
+        long pl = 0x6fcce264fcc37L * x2;
+        long ph = Math.unsignedMultiplyHigh(0x6fcce264fcc37L, x2);
+        long old = tl;
+        tl += pl;
+        th += ph + (Long.compareUnsigned(tl, old) < 0 ? 1L : 0L);
+
+        old = tl;
+        tl += c;
+        th += Long.compareUnsigned(tl, old) < 0 ? 1L : 0L;
+
+        x2 = x1;
+        x1 = tl;
+        c = th;
+        return out;
+    }
+
+    // a_0=-1. Equal coefficients on x1 and x2.
+    static long mwc64k2a2eq() {
+        final long out = x1;
+
+        long sLow = x1 + x2;
+        long sHigh = Long.compareUnsigned(sLow, x1) < 0 ? 1L : 0L;
+
+        long tl = 0xc45ec2462f86L * sLow;
+        long th = Math.unsignedMultiplyHigh(0xc45ec2462f86L, sLow)
+                + 0xc45ec2462f86L * sHigh;
+
+        long old = tl;
+        tl += c;
+        th += Long.compareUnsigned(tl, old) < 0 ? 1L : 0L;
+
+        x2 = x1;
+        x1 = tl;
+        c = th;
+        return out;
+    }
+
+    // Same as mwc64k2a2eq, kept to mirror the C++ test.
+    static long mwc64k2a2eq2() {
+        final long out = x1;
+
+        long sLow = x1 + x2;
+        long sHigh = Long.compareUnsigned(sLow, x1) < 0 ? 1L : 0L;
+
+        long tl = 0xc45ec2462f86L * sLow;
+        long th = Math.unsignedMultiplyHigh(0xc45ec2462f86L, sLow)
+                + 0xc45ec2462f86L * sHigh;
+
+        long old = tl;
+        tl += c;
+        th += Long.compareUnsigned(tl, old) < 0 ? 1L : 0L;
+
+        x2 = x1;
+        x1 = tl;
+        c = th;
+        return out;
+    }
+
+    // From MWCa0k2-0-62-58.res. a_0 general, a_1=0.
+    static long mwc64k2a1gk() {
+        long tl = 0x6595a0b6737eL * x2;
+        long th = Math.unsignedMultiplyHigh(0x6595a0b6737eL, x2);
+        long old = tl;
+        tl += c;
+        th += Long.compareUnsigned(tl, old) < 0 ? 1L : 0L;
+
+        long out = x1;
+        long newX1 = 0xba1485699989776dL * tl;
+
+        long ql = 0xe4e1b5e445c2a65L * newX1;
+        long qh = Math.unsignedMultiplyHigh(0xe4e1b5e445c2a65L, newX1);
+        long borrow = Long.compareUnsigned(tl, ql) < 0 ? 1L : 0L;
+
+        x2 = out;
+        x1 = newX1;
+        c = th - qh - borrow;
+        return out;
+    }
+
+    // From MWCa0k2-60-58.res. a_0 general.
+    static long mwc64k2a2gk() {
+        final long out = x1;
+
+        long tl = 0x22ddf8545f51c3dL * x1;
+        long th = Math.unsignedMultiplyHigh(0x22ddf8545f51c3dL, x1);
+
+        long pl = 0x3b4ba2cc0eb83d39L * x2;
+        long ph = Math.unsignedMultiplyHigh(0x3b4ba2cc0eb83d39L, x2);
+        long old = tl;
+        tl += pl;
+        th += ph + (Long.compareUnsigned(tl, old) < 0 ? 1L : 0L);
+
+        old = tl;
+        tl += c;
+        th += Long.compareUnsigned(tl, old) < 0 ? 1L : 0L;
+
+        long newX1 = 0x5a9b2e257b3e1d95L * tl;
+
+        long ql = 0x0f0cdf98a7bf45bdL * newX1;
+        long qh = Math.unsignedMultiplyHigh(0x0f0cdf98a7bf45bdL, newX1);
+        long borrow = Long.compareUnsigned(tl, ql) < 0 ? 1L : 0L;
+
+        x2 = x1;
+        x1 = newX1;
+        c = th - qh - borrow;
+        return out;
+    }
+
+    // *******   k = 3  **********************************************
+
+    // From Vigna 2021. Coefficient is 0xff..., so use a = 2^64 - q, q = -a.
+    static long MWC256() {
+        final long result = z;
+        final long q = -0xfff62cf2ccc0cdafL;
+
+        long pl = q * x;
+        long ph = Math.unsignedMultiplyHigh(q, x);
+        long tl = c - pl;
+        long borrow = Long.compareUnsigned(c, pl) < 0 ? 1L : 0L;
+        long th = x - ph - borrow;
+
+        x = y;
+        y = z;
+        z = tl;
+        c = th;
+        return result;
+    }
+
+    // From MWC1k3-00-62.res. a_0=-1, a_1=a_2=0.
+    static long mwc64k3a1() {
+        final long out = x1;
+
+        long tl = 0x14fabef33841dL * x3;
+        long th = Math.unsignedMultiplyHigh(0x14fabef33841dL, x3);
+        long old = tl;
+        tl += c;
+        th += Long.compareUnsigned(tl, old) < 0 ? 1L : 0L;
+
+        x3 = x2;
+        x2 = x1;
+        x1 = tl;
+        c = th;
+        return out;
+    }
+
+    // From MWC1k3-0-60-58.res. a_0=-1, a_1=0.
+    static long mwc64k3a2() {
+        final long out = x1;
+
+        long tl = 0x2902ebc31ec3683L * x2;
+        long th = Math.unsignedMultiplyHigh(0x2902ebc31ec3683L, x2);
+
+        long pl = 0x57baa090037L * x3;
+        long ph = Math.unsignedMultiplyHigh(0x57baa090037L, x3);
+        long old = tl;
+        tl += pl;
+        th += ph + (Long.compareUnsigned(tl, old) < 0 ? 1L : 0L);
+
+        old = tl;
+        tl += c;
+        th += Long.compareUnsigned(tl, old) < 0 ? 1L : 0L;
+
+        x3 = x2;
+        x2 = x1;
+        x1 = tl;
+        c = th;
+        return out;
+    }
+
+    // From MWC1k3-60-58.res. a_0=-1.
+    static long mwc64k3a3() {
+        final long out = x1;
+
+        long tl = 0x979f3660cbaca4L * x1;
+        long th = Math.unsignedMultiplyHigh(0x979f3660cbaca4L, x1);
+
+        long pl = 0x31dcb74b96510a8L * x2;
+        long ph = Math.unsignedMultiplyHigh(0x31dcb74b96510a8L, x2);
+        long old = tl;
+        tl += pl;
+        th += ph + (Long.compareUnsigned(tl, old) < 0 ? 1L : 0L);
+
+        pl = 0x5194d4649dcdL * x3;
+        ph = Math.unsignedMultiplyHigh(0x5194d4649dcdL, x3);
+        old = tl;
+        tl += pl;
+        th += ph + (Long.compareUnsigned(tl, old) < 0 ? 1L : 0L);
+
+        old = tl;
+        tl += c;
+        th += Long.compareUnsigned(tl, old) < 0 ? 1L : 0L;
+
+        x3 = x2;
+        x2 = x1;
+        x1 = tl;
+        c = th;
+        return out;
+    }
+
+    // Two coefficients are equal. a_0=-1, a_2=a_3.
+    static long mwc64k3a2eq() {
+        final long out = x1;
+
+        long sLow = x2 + x3;
+        long sHigh = Long.compareUnsigned(sLow, x2) < 0 ? 1L : 0L;
+
+        long tl = 0x1d0710107d5dL * sLow;
+        long th = Math.unsignedMultiplyHigh(0x1d0710107d5dL, sLow)
+                + 0x1d0710107d5dL * sHigh;
+
+        long old = tl;
+        tl += c;
+        th += Long.compareUnsigned(tl, old) < 0 ? 1L : 0L;
+
+        x3 = x2;
+        x2 = x1;
+        x1 = tl;
+        c = th;
+        return out;
+    }
+
+    // Three coefficients are equal. a_0=-1, a_1=a_2=a_3.
+    static long mwc64k3a3eq() {
+        final long out = x1;
+
+        long sLow = x1 + x2;
+        long sHigh = Long.compareUnsigned(sLow, x1) < 0 ? 1L : 0L;
+        long old = sLow;
+        sLow += x3;
+        sHigh += Long.compareUnsigned(sLow, old) < 0 ? 1L : 0L;
+
+        long tl = 0x1d495210185cL * sLow;
+        long th = Math.unsignedMultiplyHigh(0x1d495210185cL, sLow)
+                + 0x1d495210185cL * sHigh;
+
+        old = tl;
+        tl += c;
+        th += Long.compareUnsigned(tl, old) < 0 ? 1L : 0L;
+
+        x3 = x2;
+        x2 = x1;
+        x1 = tl;
+        c = th;
+        return out;
+    }
+
+    // Same recurrence as mwc64k3a1, but returns x1 xor x3.
+    static long mwc64k3a1Xor() {
+        final long out = x1 ^ x3;
+
+        long tl = 0x14fabef33841dL * x3;
+        long th = Math.unsignedMultiplyHigh(0x14fabef33841dL, x3);
+        long old = tl;
+        tl += c;
+        th += Long.compareUnsigned(tl, old) < 0 ? 1L : 0L;
+
+        x3 = x2;
+        x2 = x1;
+        x1 = tl;
+        c = th;
+        return out;
+    }
+
+    // Same recurrence as mwc64k3a2, but returns x1 xor x3.
+    static long mwc64k3a2Xor() {
+        final long out = x1 ^ x3;
+
+        long tl = 0x2902ebc31ec3683L * x2;
+        long th = Math.unsignedMultiplyHigh(0x2902ebc31ec3683L, x2);
+
+        long pl = 0x57baa090037L * x3;
+        long ph = Math.unsignedMultiplyHigh(0x57baa090037L, x3);
+        long old = tl;
+        tl += pl;
+        th += ph + (Long.compareUnsigned(tl, old) < 0 ? 1L : 0L);
+
+        old = tl;
+        tl += c;
+        th += Long.compareUnsigned(tl, old) < 0 ? 1L : 0L;
+
+        x3 = x2;
+        x2 = x1;
+        x1 = tl;
+        c = th;
+        return out;
+    }
+
+    // Same recurrence as mwc64k3a3, but returns x1 xor x2.
+    static long mwc64k3a3Xor() {
+        final long out = x1 ^ x2;
+
+        long tl = 0x979f3660cbaca4L * x1;
+        long th = Math.unsignedMultiplyHigh(0x979f3660cbaca4L, x1);
+
+        long pl = 0x31dcb74b96510a8L * x2;
+        long ph = Math.unsignedMultiplyHigh(0x31dcb74b96510a8L, x2);
+        long old = tl;
+        tl += pl;
+        th += ph + (Long.compareUnsigned(tl, old) < 0 ? 1L : 0L);
+
+        pl = 0x5194d4649dcdL * x3;
+        ph = Math.unsignedMultiplyHigh(0x5194d4649dcdL, x3);
+        old = tl;
+        tl += pl;
+        th += ph + (Long.compareUnsigned(tl, old) < 0 ? 1L : 0L);
+
+        old = tl;
+        tl += c;
+        th += Long.compareUnsigned(tl, old) < 0 ? 1L : 0L;
+
+        x3 = x2;
+        x2 = x1;
+        x1 = tl;
+        c = th;
+        return out;
+    }
+
+    // This version never returns 0, uses a while.
+    static long mwc64k3a2No0w() {
+        long out = mwc64k3a2();
+        while (out == 0L)
+            out = mwc64k3a2();
+        return out;
+    }
+
+    // This version never returns 0, uses a if.
+    static long mwc64k3a2No0i() {
+        long out = mwc64k3a2();
+        if (out == 0L) out = mwc64k3a2No0i();
+        return out;
+    }
+
+    // Mirrors C++: out += (out == 0) * mwc64k3a2(); the second draw is always done.
+    static long mwc64k3a2No0a() {
+        long out = mwc64k3a2();
+        long extra = mwc64k3a2();
+        if (out == 0L) out += extra;
+        return out;
+    }
+
+    // This version never returns 0, uses a while.
+    static long mwc64k3a3No0w() {
+        long out = mwc64k3a3();
+        while (out == 0L)
+            out = mwc64k3a3();
+        return out;
+    }
+
+    // This version never returns 0, uses a if.
+    static long mwc64k3a3No0i() {
+        long out = mwc64k3a3();
+        if (out == 0L) out = mwc64k3a3No0i();
+        return out;
+    }
+
+    // Mirrors C++: out += (out == 0) * mwc64k3a3(); the second draw is always done.
+    static long mwc64k3a3No0a() {
+        long out = mwc64k3a3();
+        long extra = mwc64k3a3();
+        if (out == 0L) out += extra;
+        return out;
+    }
+
+    // From Vigna 2021. a_0 general, a_1=a_2=0.
+    static long GMWC256() {
+        final long q = -GMWC_A3;
+
+        long pl = q * x;
+        long ph = Math.unsignedMultiplyHigh(q, x);
+        long tl = c - pl;
+        long borrow = Long.compareUnsigned(c, pl) < 0 ? 1L : 0L;
+        long th = x - ph - borrow;
+
+        x = y;
+        y = z;
+        long newZ = GMWC_A0INV * tl;
+
+        long ql = GMWC_MINUSA0 * newZ;
+        long qh = Math.unsignedMultiplyHigh(GMWC_MINUSA0, newZ);
+        long low = tl + ql;
+        long carryAdd = Long.compareUnsigned(low, tl) < 0 ? 1L : 0L;
+
+        z = newZ;
+        c = th + qh + carryAdd;
+        return z;
+    }
+
+    // From MWCa0k3-00-62.res. a_0 general, a_1=a_2=0.
+    static long mwc64k3a1gk() {
+        final long out = x1;
+
+        long tl = 0xf53334560dL * x3;
+        long th = Math.unsignedMultiplyHigh(0xf53334560dL, x3);
+        long old = tl;
+        tl += c;
+        th += Long.compareUnsigned(tl, old) < 0 ? 1L : 0L;
+
+        long newX1 = 0xa55ad7c337410603L * tl;
+
+        long ql = 0x02ce8eef308854abL * newX1;
+        long qh = Math.unsignedMultiplyHigh(0x02ce8eef308854abL, newX1);
+        long borrow = Long.compareUnsigned(tl, ql) < 0 ? 1L : 0L;
+
+        x3 = x2;
+        x2 = x1;
+        x1 = newX1;
+        c = th - qh - borrow;
+        return out;
+    }
+
+    // From MWCa0k3-0-60-58.res. a_0 general, a_1=0.
+    static long mwc64k3a2gk() {
+        final long out = x1;
+
+        long tl = 0x1a43e76662f692cL * x2;
+        long th = Math.unsignedMultiplyHigh(0x1a43e76662f692cL, x2);
+
+        long pl = 0x5a888e5764193L * x3;
+        long ph = Math.unsignedMultiplyHigh(0x5a888e5764193L, x3);
+        long old = tl;
+        tl += pl;
+        th += ph + (Long.compareUnsigned(tl, old) < 0 ? 1L : 0L);
+
+        old = tl;
+        tl += c;
+        th += Long.compareUnsigned(tl, old) < 0 ? 1L : 0L;
+
+        long newX1 = 0x9772ec11e3b050c5L * tl;
+
+        long ql = 0x0e6f81c49aeeae0dL * newX1;
+        long qh = Math.unsignedMultiplyHigh(0x0e6f81c49aeeae0dL, newX1);
+        long borrow = Long.compareUnsigned(tl, ql) < 0 ? 1L : 0L;
+
+        x3 = x2;
+        x2 = x1;
+        x1 = newX1;
+        c = th - qh - borrow;
+        return out;
+    }
+
+    // From MWCa0k3-60-58.res. a_0 general.
+    static long mwc64k3a3gk() {
+        final long out = x1;
+
+        long tl = 0x1427e7f2aedfa9cL * x1;
+        long th = Math.unsignedMultiplyHigh(0x1427e7f2aedfa9cL, x1);
+
+        long pl = 0x373ad6944cfb8d0L * x2;
+        long ph = Math.unsignedMultiplyHigh(0x373ad6944cfb8d0L, x2);
+        long old = tl;
+        tl += pl;
+        th += ph + (Long.compareUnsigned(tl, old) < 0 ? 1L : 0L);
+
+        pl = 0x0f2125fd7e3997L * x3;
+        ph = Math.unsignedMultiplyHigh(0x0f2125fd7e3997L, x3);
+        old = tl;
+        tl += pl;
+        th += ph + (Long.compareUnsigned(tl, old) < 0 ? 1L : 0L);
+
+        old = tl;
+        tl += c;
+        th += Long.compareUnsigned(tl, old) < 0 ? 1L : 0L;
+
+        long newX1 = 0xdd3034dd040dab6bL * tl;
+
+        long ql = 0x0ea08673f5e82943L * newX1;
+        long qh = Math.unsignedMultiplyHigh(0x0ea08673f5e82943L, newX1);
+        long borrow = Long.compareUnsigned(tl, ql) < 0 ? 1L : 0L;
+
+        x3 = x2;
+        x2 = x1;
+        x1 = newX1;
+        c = th - qh - borrow;
+        return out;
+    }
+
+    // ****************************************************************
+    // U(0,1) generators
+
+    static double mwc64k2a2U01() {
+        return (mwc64k2a2() >>> 11) * twom53;
+    }
+
+    static double mwc64k2a2U01w() {
+        long block53 = mwc64k2a2() >>> 11;
+        while (block53 == 0L)
+            block53 = mwc64k2a2() >>> 11;
+        return block53 * twom53;
+    }
+
+    static double mwc64k2a2U01i() {
+        long block53 = mwc64k2a2() >>> 11;
+        if (block53 == 0L) return mwc64k2a2U01i();
+        return block53 * twom53;
+    }
+
+    static double mwc64k2a2XorU01() {
+        return (mwc64k2a2Xor() >>> 11) * twom53;
+    }
+
+    static double mwc64k2a2XorU01i() {
+        long block53 = mwc64k2a2Xor() >>> 11;
+        if (block53 == 0L) return mwc64k2a2XorU01i();
+        return block53 * twom53;
+    }
+
+    static double mwc64k3a1U01() {
+        return (mwc64k3a1() >>> 11) * twom53;
+    }
+
+    static double mwc64k3a1U01w() {
+        long block53 = mwc64k3a1() >>> 11;
+        while (block53 == 0L)
+            block53 = mwc64k3a1() >>> 11;
+        return block53 * twom53;
+    }
+
+    static double mwc64k3a1U01i() {
+        long block53 = mwc64k3a1() >>> 11;
+        if (block53 == 0L) return mwc64k3a1U01i();
+        return block53 * twom53;
+    }
+
+    static double mwc64k3a1XorU01() {
+        return (mwc64k3a1Xor() >>> 11) * twom53;
+    }
+
+    static double mwc64k3a1XorU01i() {
+        long block53 = mwc64k3a1Xor() >>> 11;
+        if (block53 == 0L) return mwc64k3a1XorU01i();
+        return block53 * twom53;
+    }
+
+    static double mwc64k3a2U01() {
+        return (mwc64k3a2() >>> 11) * twom53;
+    }
+
+    static double mwc64k3a2U01w() {
+        long block53 = mwc64k3a2() >>> 11;
+        while (block53 == 0L)
+            block53 = mwc64k3a2() >>> 11;
+        return block53 * twom53;
+    }
+
+    static double mwc64k3a2U01i() {
+        long block53 = mwc64k3a2() >>> 11;
+        if (block53 == 0L) return mwc64k3a2U01i();
+        return block53 * twom53;
+    }
+
+    static double mwc64k3a2XorU01() {
+        return (mwc64k3a2Xor() >>> 11) * twom53;
+    }
+
+    static double mwc64k3a2XorU01i() {
+        long block53 = mwc64k3a2Xor() >>> 11;
+        if (block53 == 0L) return mwc64k3a2XorU01i();
+        return block53 * twom53;
+    }
+
+    static double mwc64k3a3U01w() {
+        long block53 = mwc64k3a3() >>> 11;
+        while (block53 == 0L)
+            block53 = mwc64k3a3() >>> 11;
+        return block53 * twom53;
+    }
+
+    static double mwc64k3a3U01i() {
+        long block53 = mwc64k3a3() >>> 11;
+        if (block53 == 0L) return mwc64k3a3U01i();
+        return block53 * twom53;
+    }
+
+    // *************************************************************************
+
+    static void testLoop(String rngName, LongSupplier func, long n) {
+        x = y = z = x1 = x2 = x3 = c = 12345L;
+        sum = 0L;
+        long t = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += func.getAsLong();
+        }
+        t = System.nanoTime() - t;
+        printResults(rngName, t, sum);
+    }
+
+    // *************************************************************************
+
+    public static void main (String[] args) throws java.io.FileNotFoundException {
+    	
+    	//PrintStream out = new PrintStream("C:/Users/cherrato/Documents/GitHub/Data/o-MWC-test/MWCSpeed10JavaLoc.res");// Uncomment to write restults
+    	
+    	//System.setOut(out);
+        // long n = 4;
+        // long n = 1000L * 1000L; // One million
+        // long n = 1000L * 1000L * 1000L; // One billion
+        long n = 1000L * 1000L * 10000L; // Ten billions
+
+        System.out.println("\n=========JAVA WITH LOCAL FIELDS NO HELPERS========");
+        System.out.printf("Time to generate n = %d = %.6e numbers.%n", n, (double) n);
+        System.out.println("    Generator     Time (seconds)      Sum mod 2^{64} ");
+        tottmp = System.nanoTime();
+
+        // *******   k = 1  *********************************************
+        System.out.println("k = 1 ");
+
+        testLoop("MWC128 given as a parameter to testLoop    ", TestMWCSpeedLocalsNoHelpers::MWC128, n);
+        testLoop("mwc64k1 given as a parameter to testLoop   ", TestMWCSpeedLocalsNoHelpers::mwc64k1, n);
+        testLoop("mwc64k3a2 given as a parameter to testLoop ", TestMWCSpeedLocalsNoHelpers::mwc64k3a2, n);
+        System.out.println();
+
+        
+        x = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += MWC128();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("MWC128", tmp, sum);
+        
+
+        x1 = x2 = x3 = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += mwc64k1();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("mwc64k1", tmp, sum);
+
+
+        // *******   k = 2  *********************************************
+        System.out.println("k = 2 ");
+
+        x = y = z = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += MWC192();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("MWC192", tmp, sum);
+
+        x1 = x2 = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += mwc64k2a1();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("mwc64k2a1", tmp, sum);
+
+        x1 = x2 = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += mwc64k2a2();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("mwc64k2a2", tmp, sum);
+
+        x1 = x2 = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += mwc64k2a2eq();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("mwc64k2a2eq", tmp, sum);
+
+        x1 = x2 = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += mwc64k2a2eq2();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("mwc64k2a2eq2", tmp, sum);
+
+        x1 = x2 = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += mwc64k2a1gk();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("mwc64k2a1gk", tmp, sum);
+
+        x1 = x2 = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += mwc64k2a2gk();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("mwc64k2a2gk", tmp, sum);
+
+        // *******   k = 3  *********************************************
+        System.out.println("k = 3 ");
+
+        x = y = z = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += MWC256();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("MWC256", tmp, sum);
+
+        x1 = x2 = x3 = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += mwc64k3a1();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("mwc64k3a1", tmp, sum);
+
+        x1 = x2 = x3 = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += mwc64k3a2();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("mwc64k3a2", tmp, sum);
+
+        x1 = x2 = x3 = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += mwc64k3a3();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("mwc64k3a3", tmp, sum);
+
+        x1 = x2 = x3 = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += mwc64k3a2eq();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("mwc64k3a2eq", tmp, sum);
+
+        x1 = x2 = x3 = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += mwc64k3a3eq();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("mwc64k3a3eq", tmp, sum);
+
+        x1 = x2 = x3 = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += mwc64k3a1Xor();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("mwc64k3a1Xor", tmp, sum);
+
+        x1 = x2 = x3 = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += mwc64k3a2Xor();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("mwc64k3a2Xor", tmp, sum);
+
+        x1 = x2 = x3 = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += mwc64k3a3Xor();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("mwc64k3a3Xor", tmp, sum);
+        System.out.println();
+
+        // ************************************************************
+        // a_0 < -1
+
+        x = y = z = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += GMWC256();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("GMWC256", tmp, sum);
+
+        x1 = x2 = x3 = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += mwc64k3a1gk();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("mwc64k3a1gk", tmp, sum);
+
+        x1 = x2 = x3 = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += mwc64k3a2gk();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("mwc64k3a2gk", tmp, sum);
+
+        x1 = x2 = x3 = c = 12345L;
+        sum = 0L;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            sum += mwc64k3a3gk();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResults("mwc64k3a3gk", tmp, sum);
+
+        // ******************************************************
+        System.out.println("\nUniform over (0,1) ");
+        System.out.printf("standard dev. for average = (4n)^{-1/2} =    %.8f%n",
+                1.0 / Math.sqrt(2.0 * n));
+        System.out.println("      Generator              Time (seconds)    Average ");
+        double dsum = 0.0;
+
+        // k = 2
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += mwc64k2a2U01();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k2a2U01    53           ", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += (mwc64k2a2() >>> 1) * twom63;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k2a2 U(0,1) 63          ", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += (mwc64k2a2() >>> 11) * twom53 + twom55;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k2a2 U(0,1) 53, + twom55", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += mwc64k2a2U01i();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k2a2U01i U(0,1) 53      ", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += mwc64k2a2XorU01();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k2a2XorU01 U(0,1) 53    ", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += mwc64k2a2XorU01i();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k2a2XorU01i U(0,1) 53   ", tmp, dsum / n);
+
+        System.out.println();
+
+        // k = 3
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += (mwc64k3a1() >>> 11) * twom53;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a1 U(0,1) 53          ", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += mwc64k3a1U01();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a1U01 U(0,1) 53       ", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += mwc64k3a1U01w();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a1U01w U(0,1) 53      ", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += mwc64k3a1U01i();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a1U01i U(0,1) 53      ", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += mwc64k3a1XorU01();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a1XorU01 U(0,1) 53    ", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += mwc64k3a1XorU01i();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a1XorU01i U(0,1) 53   ", tmp, dsum / n);
+
+        System.out.println();
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += (mwc64k3a2() >>> 11) * twom53;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a2 U(0,1) 53          ", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += mwc64k3a2U01();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a2U01 U(0,1) 53       ", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += mwc64k3a2U01w();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a2U01w U(0,1) 53      ", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += mwc64k3a2U01i();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a2U01i U(0,1) 53      ", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += mwc64k3a2XorU01();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a2XorU01 U(0,1) 53    ", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += mwc64k3a2XorU01i();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a2XorU01i U(0,1) 53   ", tmp, dsum / n);
+
+        System.out.println();
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += (mwc64k3a3() >>> 11) * twom53;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a3 U(0,1) 53          ", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += mwc64k3a3U01w();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a3U01w U(0,1) 53      ", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += mwc64k3a3U01i();
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a3U01i U(0,1) 53      ", tmp, dsum / n);
+
+        // ******************************************************************
+        // Extra tests that appear after return 0 in the C++ file.
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += unsignedToDouble(mwc64k2a2()) * twom64;
+        }
+        printResultsDouble("mwc64k2a2 U(0,1) 64", System.nanoTime() - tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += (mwc64k2a2Xor() >>> 11) * twom53;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k2a2Xor U(0,1) 53", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += (mwc64k2a2Xor() >>> 1) * twom63;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k2a2Xor U(0,1) 63", tmp, dsum / n);
+
+        x1 = x2 = x3 = c = 12345L;
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += unsignedToDouble(mwc64k2a2Xor()) * twom64;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k2a2Xor U(0,1) 64", tmp, dsum / n);
+
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += (mwc64k3a1() >>> 11) * twom53;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a1 U(0,1) 53", tmp, dsum / n);
+
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += (mwc64k3a1() >>> 1) * twom63;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a1 U(0,1) 63", tmp, dsum / n);
+
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += unsignedToDouble(mwc64k3a1()) * twom64;
+        }
+        printResultsDouble("mwc64k3a1 U(0,1) 64", System.nanoTime() - tmp, dsum / n);
+
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += (mwc64k3a1Xor() >>> 11) * twom53;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a1Xor U(0,1)", tmp, dsum / n);
+
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += (mwc64k3a1Xor() >>> 1) * twom63;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a1Xor U(0,1) 63", tmp, dsum / n);
+
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += unsignedToDouble(mwc64k3a1Xor()) * twom64;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a1Xor U(0,1) 64", tmp, dsum / n);
+
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += (mwc64k3a2() >>> 11) * twom53;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a2 U(0,1)   ", tmp, dsum / n);
+
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += (mwc64k3a2() >>> 1) * twom63;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a2 U(0,1) 63", tmp, dsum / n);
+
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += unsignedToDouble(mwc64k3a2()) * twom64;
+        }
+        printResultsDouble("mwc64k3a2 U(0,1) 64", System.nanoTime() - tmp, dsum / n);
+
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += (mwc64k3a2Xor() >>> 11) * twom53;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a2Xor U(0,1) 53", tmp, dsum / n);
+
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += (mwc64k3a2Xor() >>> 1) * twom63;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a2Xor U(0,1) 63", tmp, dsum / n);
+
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += unsignedToDouble(mwc64k3a2Xor()) * twom64;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a2Xor U(0,1) 64", tmp, dsum / n);
+
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += (mwc64k3a3() >>> 11) * twom53;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a3 U(0,1) 53 ", tmp, dsum / n);
+
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += (mwc64k3a3() >>> 1) * twom63;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a3 U(0,1) 63 ", tmp, dsum / n);
+
+        dsum = 0.0;
+        tmp = System.nanoTime();
+        for (long i = 0; i < n; i++) {
+            dsum += unsignedToDouble(mwc64k3a3()) * twom64;
+        }
+        tmp = System.nanoTime() - tmp;
+        printResultsDouble("mwc64k3a3 U(0,1) 64 ", tmp, dsum / n);
+
+        System.out.println();
+        printResultsDouble("Total computing time: ", System.nanoTime() - tottmp, 0);
+    }
+}

--- a/src/main/docs/examples/rqmcexperiments/GenzContinuous.java
+++ b/src/main/docs/examples/rqmcexperiments/GenzContinuous.java
@@ -38,8 +38,8 @@ public class GenzContinuous implements MonteCarloModelDouble {
       for (int j = 0; j < s; j++) {
          if (!(c[j] > 0.0))
             throw new IllegalArgumentException("c[" + j + "] must be positive");
-         if (!(w[j] > 0.0 && w[j] < 1.0))
-            throw new IllegalArgumentException("w[" + j + "] must be in (0, 1)");
+         if (!(w[j] >= 0.0 && w[j] < 1.0))
+            throw new IllegalArgumentException("w[" + j + "] must be in [0, 1)");
       }
 
       this.s = s;

--- a/src/main/docs/examples/rqmcexperiments/GenzCornerPeak.java
+++ b/src/main/docs/examples/rqmcexperiments/GenzCornerPeak.java
@@ -28,42 +28,21 @@ public class GenzCornerPeak implements MonteCarloModelDouble {
     * @param s dimension of the function
     * @param c scale parameters, all strictly positive
     */
-//   public GenzCornerPeak(int s, double[] c) {
-//      if (s <= 0)
-//         throw new IllegalArgumentException("s must be positive");
-//      if (c == null || c.length != s)
-//         throw new IllegalArgumentException("c must have length s");
-//
-//      for (int j = 0; j < s; j++) {
-//         if (!(c[j] > 0.0))
-//            throw new IllegalArgumentException("c[" + j + "] must be positive");
-//      }
-//
-//      this.s = s;
-//      this.c = c.clone();
-//      this.exactMean = computeExactMean();
-//   }
-   
-   //// for test:
    public GenzCornerPeak(int s, double[] c) {
-	   this(s, c, true);
-	}
+      if (s <= 0)
+         throw new IllegalArgumentException("s must be positive");
+      if (c == null || c.length != s)
+         throw new IllegalArgumentException("c must have length s");
 
-	public GenzCornerPeak(int s, double[] c, boolean computeMean) {
-	   if (s <= 0)
-	      throw new IllegalArgumentException("s must be positive");
-	   if (c == null || c.length != s)
-	      throw new IllegalArgumentException("c must have length s");
+      for (int j = 0; j < s; j++) {
+         if (!(c[j] > 0.0))
+            throw new IllegalArgumentException("c[" + j + "] must be positive");
+      }
 
-	   for (int j = 0; j < s; j++) {
-	      if (!(c[j] > 0.0))
-	         throw new IllegalArgumentException("c[" + j + "] must be positive");
-	   }
-
-	   this.s = s;
-	   this.c = c.clone();
-	   this.exactMean = computeMean ? computeExactMean() : Double.NaN;
-	}
+      this.s = s;
+      this.c = c.clone();
+      this.exactMean = computeExactMean();
+   }
 
    /**
     * Simulates one observation of the model.

--- a/src/main/docs/examples/rqmcexperiments/GenzCornerPeak.java
+++ b/src/main/docs/examples/rqmcexperiments/GenzCornerPeak.java
@@ -28,21 +28,42 @@ public class GenzCornerPeak implements MonteCarloModelDouble {
     * @param s dimension of the function
     * @param c scale parameters, all strictly positive
     */
+//   public GenzCornerPeak(int s, double[] c) {
+//      if (s <= 0)
+//         throw new IllegalArgumentException("s must be positive");
+//      if (c == null || c.length != s)
+//         throw new IllegalArgumentException("c must have length s");
+//
+//      for (int j = 0; j < s; j++) {
+//         if (!(c[j] > 0.0))
+//            throw new IllegalArgumentException("c[" + j + "] must be positive");
+//      }
+//
+//      this.s = s;
+//      this.c = c.clone();
+//      this.exactMean = computeExactMean();
+//   }
+   
+   //// for test:
    public GenzCornerPeak(int s, double[] c) {
-      if (s <= 0)
-         throw new IllegalArgumentException("s must be positive");
-      if (c == null || c.length != s)
-         throw new IllegalArgumentException("c must have length s");
+	   this(s, c, true);
+	}
 
-      for (int j = 0; j < s; j++) {
-         if (!(c[j] > 0.0))
-            throw new IllegalArgumentException("c[" + j + "] must be positive");
-      }
+	public GenzCornerPeak(int s, double[] c, boolean computeMean) {
+	   if (s <= 0)
+	      throw new IllegalArgumentException("s must be positive");
+	   if (c == null || c.length != s)
+	      throw new IllegalArgumentException("c must have length s");
 
-      this.s = s;
-      this.c = c.clone();
-      this.exactMean = computeExactMean();
-   }
+	   for (int j = 0; j < s; j++) {
+	      if (!(c[j] > 0.0))
+	         throw new IllegalArgumentException("c[" + j + "] must be positive");
+	   }
+
+	   this.s = s;
+	   this.c = c.clone();
+	   this.exactMean = computeMean ? computeExactMean() : Double.NaN;
+	}
 
    /**
     * Simulates one observation of the model.
@@ -65,37 +86,77 @@ public class GenzCornerPeak implements MonteCarloModelDouble {
    public double getPerformance() {
       return Math.pow(1.0 + sum, -(s + 1)) - exactMean;
    }
-
+   
    /**
     * Computes the exact mean of the Genz corner peak function.
     *
-    * @return exact integral over @f$[0,1]^s@f$
-    */
-   private double computeExactMean() {
-      double prod = 1.0;
-      for (int j = 0; j < s; j++)
-         prod *= c[j];
-
-      return subsetSum(0, 0.0, 0) / (Num.factorial(s) * prod); // Using recursive function, iteration maybe more efficient but long 
-   }
-
-   /**
-    * Computes the subset sum in the exact integral formula.
+    * The exact formula contains a sum over all @f$2^s@f$ subsets of the
+    * scale parameters. This implementation enumerates the subsets using a
+    * Gray-code ordering. Since two consecutive Gray codes differ by only one bit,
+    * the current subset sum can be updated by adding or removing one @f$c_j@f$,
+    * instead of recomputing the sum from scratch for each subset.
     *
-    * @param j current coordinate index
-    * @param partialSum sum of selected parameters
-    * @param cardinality number of selected parameters
-    * @return contribution to the subset sum
+    * Kahan summation is used separately from the Gray-code enumeration to reduce
+    * floating-point roundoff in the alternating subset sum.
+    *
+    * A recursive include/exclude implementation gives the same mathematical result
+    * and is shorter and easier to read, but this iterative Gray-code version is relatively
+    * faster for larger dimensions. The cost remains @f$O(2^s)@f$.
+    *
+    * @return exact integral over @f$[0,1]^s@f$
+    * @throws IllegalArgumentException if @f$s \ge 63@f$, since @f$2^s@f$ subsets
+    *         cannot be represented safely with a `long`
     */
-   private double subsetSum(int j, double partialSum, int cardinality) {
-      if (j == s) {
-         double sign = (cardinality % 2 == 0) ? 1.0 : -1.0;
-         return sign / (1.0 + partialSum);
-      }
+   public double computeExactMean() {
+	   if (s >= 63) {
+	      throw new IllegalArgumentException(
+	         "Exact subset enumeration needs 2^s subsets; s is too large."
+	      );
+	   }
 
-      return subsetSum(j + 1, partialSum, cardinality)
-            + subsetSum(j + 1, partialSum + c[j], cardinality + 1);
-   }
+	   double prod = 1.0;
+	   for (int j = 0; j < s; j++)
+	      prod *= c[j];
+
+	   double subsetSum = 0.0;
+	   double compensation = 0.0; // Kahan compensation
+
+	   long previousGray = 0L;
+	   double partialSum = 0.0;
+	   int cardinality = 0;
+
+	   long nSubsets = 1L << s;
+
+	   for (long mask = 0; mask < nSubsets; mask++) {
+	      long gray = mask ^ (mask >> 1);
+
+	      if (mask != 0) {
+	         long changedBit = gray ^ previousGray;
+	         int j = Long.numberOfTrailingZeros(changedBit);
+
+	         if ((gray & changedBit) != 0L) {
+	            partialSum += c[j];
+	            cardinality++;
+	         } else {
+	            partialSum -= c[j];
+	            cardinality--;
+	         }
+	      }
+
+	      double sign = (cardinality % 2 == 0) ? 1.0 : -1.0;
+	      double term = sign / (1.0 + partialSum);
+
+	      // Kahan summation
+	      double y = term - compensation;
+	      double t = subsetSum + y;
+	      compensation = (t - subsetSum) - y;
+	      subsetSum = t;
+
+	      previousGray = gray;
+	   }
+
+	   return subsetSum / (Num.factorial(s) * prod);
+	}
 
 
    @Override

--- a/src/main/docs/examples/rqmcexperiments/GenzCornerPeak.java
+++ b/src/main/docs/examples/rqmcexperiments/GenzCornerPeak.java
@@ -147,9 +147,5 @@ public class GenzCornerPeak implements MonteCarloModelDouble {
    public String getTag() {
       return "GenzCornerPeak";
    }
-   
-   /////////for test
-   public double getExactMean() {
-	   return exactMean;
-	}
+
 }

--- a/src/main/docs/examples/rqmcexperiments/GenzDiscontinuous.java
+++ b/src/main/docs/examples/rqmcexperiments/GenzDiscontinuous.java
@@ -45,8 +45,8 @@ public class GenzDiscontinuous implements MonteCarloModelDouble {
       }
 
       for (int j = 0; j < 2; j++) {
-         if (!(w[j] > 0.0 && w[j] < 1.0))
-            throw new IllegalArgumentException("w[" + j + "] must be in (0, 1)");
+         if (!(w[j] >= 0.0 && w[j] < 1.0))
+            throw new IllegalArgumentException("w[" + j + "] must be in [0, 1)");
       }
 
       this.s = s;

--- a/src/main/docs/examples/rqmcexperiments/GenzGaussian.java
+++ b/src/main/docs/examples/rqmcexperiments/GenzGaussian.java
@@ -43,8 +43,8 @@ public class GenzGaussian implements MonteCarloModelDouble {
       for (int j = 0; j < s; j++) {
          if (c[j] <= 0.0)
             throw new IllegalArgumentException("c[" + j + "] must be positive");
-         if (w[j] <= 0.0 || w[j] >= 1.0)
-            throw new IllegalArgumentException("w[" + j + "] must be in (0, 1)");
+         if (w[j] < 0.0 || w[j] >= 1.0)
+            throw new IllegalArgumentException("w[" + j + "] must be in [0, 1)");
 
          cSquared[j] = c[j] * c[j];
       }
@@ -103,4 +103,9 @@ public class GenzGaussian implements MonteCarloModelDouble {
    public String getTag() {
       return "GenzGaussian";
    }
+   
+   /////////for test
+   public double getExactMean() {
+	   return exactMean;
+	}
 }

--- a/src/main/docs/examples/rqmcexperiments/GenzProductPeak.java
+++ b/src/main/docs/examples/rqmcexperiments/GenzProductPeak.java
@@ -44,8 +44,8 @@ public class GenzProductPeak implements MonteCarloModelDouble {
       for (int j = 0; j < s; j++) {
          if (!(this.c[j] > 0.0))
             throw new IllegalArgumentException("c[" + j + "] must be positive");
-         if (!(this.w[j] > 0.0 && this.w[j] < 1.0))
-            throw new IllegalArgumentException("w[" + j + "] must be in (0, 1)");
+         if (!(this.w[j] >= 0.0 && this.w[j] < 1.0))
+            throw new IllegalArgumentException("w[" + j + "] must be in [0, 1)");
 
          cInvSquared[j] = 1.0 / (this.c[j] * this.c[j]);
       }

--- a/src/main/java/umontreal/ssj/rng/MWC64k2a2.java
+++ b/src/main/java/umontreal/ssj/rng/MWC64k2a2.java
@@ -32,31 +32,31 @@ public class MWC64k2a2 extends RandomStreamBase {
 	
    private static final long serialVersionUID = 20260518L;
    
-   /** State components x_{n-1}, x_{n-2} and c_{n-1} interpreted as unsigned 64-bit. */
+   // State components x_{n-1}, x_{n-2} and c_{n-1} interpreted as unsigned 64-bit. 
    private long x1, x2, carry;
-   /** First coefficient a1. */
+   // First coefficient a1. 
    private static final long A1 = 193154555888013165L;
-   /** Second coefficient a2. */
-   private static final long A2 = 1966812196490295L;   
-//   private static final long  A1 = 556348944096481337L, A2 = 8250136865355103L; // Used in cpp code for jumps
-
-   /** 2^(-53), used to convert 53 random bits to a double. */
+   // Second coefficient a2. 
+   private static final long A2 = 1966812196490295L;
+// private static final long  A1 = 556348944096481337L, A2 = 8250136865355103L; // Used in cpp code for jumps
+   
+   // 2^(-53), used to convert 53 random bits to a double. 
    private static final double NORM53 = 0x1.0p-53;
-   /** Stream spacing: 2^113 generated values. */
+   // Stream spacing: 2^113 generated values. 
    private static final int STREAM_ADVANCE_EXPONENT =  113;
-   /** Substream spacing: 2^62	 generated values. */
+   // Substream spacing: 2^62	 generated values. 
    private static final int SUBSTREAM_ADVANCE_EXPONENT = 62;
 
-   /** Seed used for the next created stream: {x_{n-2}, x_{n-1}, carry}. */
+   // Seed used for the next created stream: {x_{n-2}, x_{n-1}, carry}. 
    private static long[] nextSeed = {12345L, 12345L, 12345L}; 
-   /** Initial state of this stream. */
+   //Initial state of this stream. 
    private long[] Ig;
-   /** Beginning state of the current substream of stream. */
+   // Beginning state of the current substream of stream. 
    private long[] Bg;
   
-   /**
-    * Precomputed BigInteger constants for the MWC-to-LCG jump transformation.
-    */
+   
+    // Precomputed BigInteger constants for the MWC-to-LCG jump transformation.
+    
    private static final BigInteger BI_B = BigInteger.ONE.shiftLeft(64); // b = 2^64
    private static final BigInteger BI_A1 = BigInteger.valueOf(A1);
    private static final BigInteger BI_A2 = BigInteger.valueOf(A2); 
@@ -78,13 +78,13 @@ public class MWC64k2a2 extends RandomStreamBase {
 //   /*For A1 = 193154555888013165L; A2 = 1966812196490295L; STREAM_ADVANCE_EXPONENT = 113; SUBSTREAM_ADVANCE_EXPONENT = 62
 //    * These values are precalculated and hardcoded here 
 //    * */
-//   private static final BigInteger STREAM_K_X2 = new BigInteger("550287765979488443922754971547870548747622917622202515");// Ony for the given A1, A2 and the given jumpsizes
-//   private static final BigInteger STREAM_K_X1 = new BigInteger("590664228179752031471436901652469203082748750179775222");// Ony for the given A1, A2 and the given jumpsizes
-//   private static final BigInteger STREAM_K_C  = new BigInteger("521510005202858839425516464682983339842500770120428048");// Ony for the given A1, A2 and the given jumpsizes
-//   private static final BigInteger  SUBSTREAM_K_X2 = new BigInteger("253956167587244238733053471042992883266608765200613794");// Ony for the given A1, A2 and the given jumpsizes
-//   private static final BigInteger SUBSTREAM_K_X1 = new BigInteger("334142836076716064087784195971406862825997835485950288");
-//   private static final BigInteger SUBSTREAM_K_C  = new BigInteger("475660625350411904999072789094749200216738394742542956");// Ony for the given A1, A2 and the given jumpsizes
-  
+//   private static final BigInteger STREAM_K_X2 = new BigInteger("550287765979488443922754971547870548747622917622202515");//Only for the given A1, A2 and the given jumpsizes
+//   private static final BigInteger STREAM_K_X1 = new BigInteger("590664228179752031471436901652469203082748750179775222");//Only for the given A1, A2 and the given jumpsizes
+//   private static final BigInteger STREAM_K_C  = new BigInteger("521510005202858839425516464682983339842500770120428048");//Only for the given A1, A2 and the given jumpsizes
+//   private static final BigInteger  SUBSTREAM_K_X2 = new BigInteger("253956167587244238733053471042992883266608765200613794");// Only for the given A1, A2 and the given jumpsizes
+//   private static final BigInteger SUBSTREAM_K_X1 = new BigInteger("334142836076716064087784195971406862825997835485950288");//Only for the given A1, A2 and the given jumpsizes
+//   private static final BigInteger SUBSTREAM_K_C  = new BigInteger("475660625350411904999072789094749200216738394742542956");//Only for the given A1, A2 and the given jumpsizes
+ 
    /**
     * Constructs a new stream.
     */
@@ -218,13 +218,6 @@ public class MWC64k2a2 extends RandomStreamBase {
    }
    
    /**
-    * Another possibility to avoid returning 0 ?
-    */
-//   protected double nextValue2() {
-//      return ((nextNumber() >>> 11) + 0.5) * NORM53;
-//   }
-   
-   /**
     * Returns a random long in [i, j].
     *
     * @param i lower bound
@@ -280,7 +273,7 @@ public class MWC64k2a2 extends RandomStreamBase {
 	      return i + (res / q);
 	   }
    
-   // return a block of b bits (int)
+   // return a block of b bits (int):
    public long nextBitsLong(int b) {
 	    return nextNumber() >>> (64 - b);
 	}
@@ -358,6 +351,7 @@ public class MWC64k2a2 extends RandomStreamBase {
     */
    public MWC64k2a2 clone() {
       MWC64k2a2 copy = (MWC64k2a2) super.clone();
+
       copy.Ig = Ig.clone();               // Copy stream-start state.
       copy.Bg = Bg.clone();               // Copy substream-start state.
 
@@ -428,36 +422,53 @@ public class MWC64k2a2 extends RandomStreamBase {
    /**
     * Advances the current stream state by n steps.
     *
-    * @param n number of steps
+    * This method is for a general jump size n. It does not use
+    * advanceStateFixedJump and does not compute fixed-jump coefficients.
+    *
+    * It maps the current MWC state to the equivalent LCG state, applies
+    * the LCG jump, then converts the result back to the MWC state.
+    *
+    * @param n number of steps to jump
     */
-   void advanceStateByJump(long n) { // use same code as for fixedsize jumps to test them, but normally for varying size this is slower, normal computing is faster.
-	   if (n < 0) {
-	      throw new IllegalArgumentException("Jump step n cannot be negative.");
-	   }
-	   if (n == 0) {
-	      return;
-	   }
+   public void advanceStateByJump(long n) {
+      if (n < 0)
+         throw new IllegalArgumentException("Jump step n cannot be negative.");
 
-	   long[] state = getState();
+      if (n == 0)
+         return;
 
-	   BigInteger jumpMultiplier =
-	         BI_B_INV.modPow(BigInteger.valueOf(n), BI_M);
-	   
-	   BigInteger kX2 =
-			   jumpMultiplier.multiply( BigInteger.ONE.subtract(BI_A1.multiply(BI_B))).mod(BI_M);
+      BigInteger stateX2 = toUnsignedBigInt(x2);
+      BigInteger stateX1 = toUnsignedBigInt(x1);
+      BigInteger stateCarry = BigInteger.valueOf(carry);
 
-	   BigInteger kX1 =
-			   jumpMultiplier.multiply(BI_B).mod(BI_M);
+//       Map the current MWC state to the equivalent LCG state:
+//        y =   (1 - A1*b)*x2 + b*x1 + b^2*carry mod m
 
-	   BigInteger kC =
-			   jumpMultiplier.multiply(BI_B2).mod(BI_M);
+      BigInteger y =
+            BI_MAP_X2.multiply(stateX2)
+          .add(BI_B.multiply(stateX1))
+          .add(BI_B2.multiply(stateCarry))
+          .mod(BI_M);
 
-	   advanceStateFixedJump(state, kX2, kX1, kC);
+      // Apply the LCG jump: y_new = (b^(-1))^n * y mod m.
+      BigInteger sigma =
+            BI_B_INV.modPow(BigInteger.valueOf(n), BI_M)
+          .multiply(y)
+          .mod(BI_M);
 
-	   x2 = state[0];
-	   x1 = state[1];
-	   carry = state[2];
-	}
+       // Convert the jumped LCG state back to the MWC state.
+      long newX2 = sigma.longValue();
+      sigma = sigma.shiftRight(64);
+
+      sigma = sigma.add(BI_A1.multiply(toUnsignedBigInt(newX2)));
+
+      long newX1 = sigma.longValue();
+      long newCarry = sigma.shiftRight(64).longValue();
+
+      x2 = newX2;
+      x1 = newX1;
+      carry = newCarry;
+   }
    
    //for test
    public long nextRaw()

--- a/src/main/java/umontreal/ssj/rng/MWC64k3a2.java
+++ b/src/main/java/umontreal/ssj/rng/MWC64k3a2.java
@@ -41,29 +41,29 @@ public class MWC64k3a2 extends RandomStreamBase {
 	
    private static final long serialVersionUID = 20260518L;
    
-   /** State components x_{n-1}, x_{n-2}, x_{n-3} and c_{n-1} interpreted as unsigned 64-bit. */
+   // State components x_{n-1}, x_{n-2}, x_{n-3} and c_{n-1} interpreted as unsigned 64-bit. 
    private long x1, x2, x3, carry;
-   /** Second coefficient a2. */
+   //Second coefficient a2. 
    private static final long A2 = 184698970548483715L;
-   /** Third coefficient a3. */
+   //Third coefficient a3. 
    private static final long A3 = 6028691832887L;   
 //   private static final long A2 = 0x320fbe97bef0f95L, A3 = 0x4a1849ec18bfa6L; // for jumps comparaison with cpp
 
-   /** 2^(-53), used to convert 53 random bits to a double. */
+   //2^(-53), used to convert 53 random bits to a double. 
    private static final double NORM53 = 0x1.0p-53;
    private static final int STREAM_ADVANCE_EXPONENT = 169;
    private static final int SUBSTREAM_ADVANCE_EXPONENT = 118;
 
-   /** Seed used for the next created stream: {x_{n-3}, x_{n-2}, x_{n-1}, carry}. */
+   //Seed used for the next created stream: {x_{n-3}, x_{n-2}, x_{n-1}, carry}. 
    private static long[] nextSeed = {1L, 3L, 4L, 5L};
-   /** Initial state of this stream. */
+   // Initial state of this stream. 
    private long[] Ig;
-   /** Beginning state of the current substream of stream. */
+   //Beginning state of the current substream of stream. 
    private long[] Bg;
   
-   /**
-    * Precomputed BigInteger constants for the MWC-to-LCG jump transformation.
-    */
+   
+   // Precomputed BigInteger constants for the MWC-to-LCG jump transformation.
+    
    private static final BigInteger BI_B = BigInteger.ONE.shiftLeft(64); // b = 2^64
    private static final BigInteger BI_B2 = BigInteger.ONE.shiftLeft(128); // b^2
    private static final BigInteger BI_B3 = BigInteger.ONE.shiftLeft(192); // b^3
@@ -83,12 +83,12 @@ public class MWC64k3a2 extends RandomStreamBase {
    private static final BigInteger SUBSTREAM_K_X2 = SUBSTREAM_JUMP_MULTIPLIER.multiply(BI_B).mod(BI_M); // K_x2 = J*b mod m
    private static final BigInteger SUBSTREAM_K_X1 = SUBSTREAM_JUMP_MULTIPLIER.multiply(BI_B2).mod(BI_M); // K_x1 = J*b^2 mod m
    private static final BigInteger SUBSTREAM_K_C = SUBSTREAM_JUMP_MULTIPLIER.multiply(BI_B3).mod(BI_M); // K_c = J*b^3 mod m
-   
-//   /*For 	A2 = 184698970548483715L;
+    
+//  /*For 	A2 = 184698970548483715L;
 //		     A3 = 6028691832887L;
 //		     STREAM_ADVANCE_EXPONENT = 169;
 //		     SUBSTREAM_ADVANCE_EXPONENT= 118; The values are : 
-//    * */
+//   * */
 //   private static final BigInteger STREAM_K_X3 = new BigInteger("30761207224142103968985508472479115773948763076232986832853996703743926");// Only for the given Ai, and jump sizes
 //   private static final BigInteger STREAM_K_X2 = new BigInteger("2872972596550318317758382057880878886623467367682449388684617761028650");
 //   private static final BigInteger STREAM_K_X1 = new BigInteger("4069686296670218292987053305317065107287547089332977129336044355568643");
@@ -376,6 +376,7 @@ public class MWC64k3a2 extends RandomStreamBase {
     */
    public MWC64k3a2 clone() {
       MWC64k3a2 copy = (MWC64k3a2) super.clone();
+
       copy.Ig = Ig.clone();               // Copy stream-start state.
       copy.Bg = Bg.clone();               // Copy substream-start state.
 
@@ -453,40 +454,63 @@ public class MWC64k3a2 extends RandomStreamBase {
    /**
     * Advances the current stream state by n steps.
     *
-    * @param n number of steps
+    * This method is used for a general jump size n. It does not use the
+    * precomputed fixed-jump constants, because those constants are useful only
+    * for fixed stream/substream jumps.
+    *
+    * The method first maps the current MWC state to the equivalent LCG state,
+    * applies the LCG jump, then converts the result back to the MWC state.
+    *
+    * @param n number of steps to jump
     */
-   void advanceStateByJump(long n) {
-	   if (n < 0) {
-	      throw new IllegalArgumentException("Jump step n cannot be negative.");
-	   }
-	   if (n == 0) {
-	      return;
-	   }
+   public void advanceStateByJump(long n) {
+      if (n < 0L)
+         throw new IllegalArgumentException("Jump step n cannot be negative.");
 
-	   long[] state = getState();
+      if (n == 0)
+         return;
 
-	   BigInteger jumpMultiplier =
-	         BI_B_INV.modPow(BigInteger.valueOf(n), BI_M);
+      BigInteger stateX3 = toUnsignedBigInt(x3);
+      BigInteger stateX2 = toUnsignedBigInt(x2);
+      BigInteger stateX1 = toUnsignedBigInt(x1);
+      BigInteger stateCarry = BigInteger.valueOf(carry);
 
-	   BigInteger kX3 =
-	         jumpMultiplier.multiply(BI_MAP_X3).mod(BI_M);
+//       Map the current MWC state to the equivalent LCG state:
+//        y =  (1 - A2*b^2)*x3 + b*x2 + b^2*x1 + b^3*carry mod m
+      BigInteger y =
+            BI_MAP_X3.multiply(stateX3)
+          .add(BI_B.multiply(stateX2))
+          .add(BI_B2.multiply(stateX1))
+          .add(BI_B3.multiply(stateCarry))
+          .mod(BI_M);
 
-	   BigInteger kX2 =
-	         jumpMultiplier.multiply(BI_B).mod(BI_M);
+      // Apply the LCG jump: y_new = (b^(-1))^n * y mod m.
+      BigInteger sigma =
+            BI_B_INV.modPow(BigInteger.valueOf(n), BI_M)
+          .multiply(y)
+          .mod(BI_M);
 
-	   BigInteger kX1 =
-	         jumpMultiplier.multiply(BI_B2).mod(BI_M);
+//      Convert the jumped LCG state back to the MWC state. For MWC64k3a2, A1 = 0, so the inverse reconstruction is:
+//        newX3 = low 64 bits of sigma
+//        newX2 = next 64 bits
+//        then correct the remaining part with A2*newX3.
 
-	   BigInteger kCarry =
-	         jumpMultiplier.multiply(BI_B3).mod(BI_M);
+      long newX3 = sigma.longValue();
+      sigma = sigma.shiftRight(64);
 
-	   advanceStateFixedJump(state, kX3, kX2, kX1, kCarry);
+      long newX2 = sigma.longValue();
+      sigma = sigma.shiftRight(64);
 
-	   x3 = state[0];
-	   x2 = state[1];
-	   x1 = state[2];
-	   carry = state[3];
-	}
+      sigma = sigma.add(BI_A2.multiply(toUnsignedBigInt(newX3)));
+
+      long newX1 = sigma.longValue();
+      long newCarry = sigma.shiftRight(64).longValue();
+
+      x3 = newX3;
+      x2 = newX2;
+      x1 = newX1;
+      carry = newCarry;
+   }
    
    //public method for nextnumber test
    public long nextRaw()


### PR DESCRIPTION
This PR includes three updates:

Adds new rng experiments classes under rngexperiments:
CompareMWCvsCpp
TestMWCSpeedLocalsNoHelpers
TestMWCSpeedHelpers
TestMWC64k3a2Jump
RngFixedJumpSpeed
Updates MWC64k2a2 and MWC64k3a2 to make jump by n more efficient.
Updates the Genz function classes to allow w = 0, changing the valid range from (0, 1) to [0, 1).