### PR TITLE
Develop Otman : Update MWC generators and add RNG speed experiments

### DIFF
--- a/src/main/docs/examples/rngexperiments/RngCommonOutputSpeed.java
+++ b/src/main/docs/examples/rngexperiments/RngCommonOutputSpeed.java
@@ -1,0 +1,1225 @@
+package rngexperiments;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Locale;
+import java.util.random.RandomGenerator;
+import java.util.random.RandomGeneratorFactory;
+
+import umontreal.ssj.rng.MWC64k2a2;
+import umontreal.ssj.rng.MWC64k3a2;
+import umontreal.ssj.rng.MRG32k3a;
+import umontreal.ssj.rng.LFSR258;
+
+/**
+ * Simple output speed benchmark for common random stream methods.
+ *
+ * Compared generators:
+ *
+ * MWC64k2a2
+ * MWC64k3a2
+ * MRG32k3a
+ * LFSR258
+ * L64X128StarStarRandom
+ * L64X128MixRandom
+ * L64X256MixRandom
+ * L64X1024MixRandom
+ *
+ * Tested methods:
+ *
+ * nextDouble()
+ * nextDoubleNonzero()
+ * nextInt(i, j)
+ * nextLong(i, j)
+ *
+ * The benchmark uses one warmup run followed by timed runs. The generator is
+ * reset once before the warmup run, then the timed runs consume consecutive
+ * values without resetting.
+ *
+ * The benchmark avoids generator wrappers, lambdas, reflection, and adapter
+ * classes. Each timed loop calls the generator method directly.
+ */
+public class RngCommonOutputSpeed {
+
+    static final boolean WRITE_FILE = true;
+
+    static final int M = 100_000_000;
+    static final String M_LABEL = "1e8";
+
+    static final int WARMUP_RUNS = 1;
+    static final int TIMED_RUNS = 5;
+
+    static final int INT_I = 0;
+    static final int INT_J = 1_000_000;
+
+    static final long LONG_I = 0L;
+    static final long LONG_J = 1_000_000_000_000L;
+
+    static final long JAVA_SEED = 12345L;
+
+    static final String JAVA_L64X128_STARSTAR = "L64X128StarStarRandom";
+    static final String JAVA_L64X128_MIX = "L64X128MixRandom";
+    static final String JAVA_L64X256_MIX = "L64X256MixRandom";
+    static final String JAVA_L64X1024_MIX = "L64X1024MixRandom";
+
+    static double doubleSink = 0.0;
+    static long intSink = 0L;
+    static long longSink = 0L;
+
+    public static void main(String[] args) throws IOException {
+        StringBuilder out = new StringBuilder();
+        String output_file = "/home/otman/Documents/GitHub/Data/o-MWC-test/RngCommonOutputSpeed2.res";
+
+        out.append("RNG common output speed benchmark\n");
+        out.append("M = ").append(M_LABEL).append(" calls per run (").append(M).append(")\n");
+        out.append("Warmup runs = ").append(WARMUP_RUNS).append(" run of ")
+           .append(M_LABEL).append(" calls, excluded from timing result\n");
+        out.append("Timed runs = ").append(TIMED_RUNS).append(" runs of ")
+           .append(M_LABEL).append(" calls\n");
+        out.append("Average time = average of ").append(TIMED_RUNS)
+           .append(" timed runs, each with ").append(M_LABEL).append(" calls\n\n");
+
+        out.append("Generators:\n");
+        out.append("- MWC64k2a2\n");
+        out.append("- MWC64k3a2\n");
+        out.append("- MRG32k3a\n");
+        out.append("- LFSR258\n");
+        out.append("- L64X128StarStarRandom\n");
+        out.append("- L64X128MixRandom\n");
+        out.append("- L64X256MixRandom\n");
+        out.append("- L64X1024MixRandom\n\n");
+
+        out.append("Benchmark notes:\n");
+        out.append("- Each generator is reset once before warmup. Timed runs continue from the state reached after warmup.\n");
+        out.append("- The mean is computed over ").append(TIMED_RUNS).append(" * ")
+           .append(M_LABEL).append(" timed values; warmup values are excluded.\n");
+        out.append("- MWC nextDoubleNonzero() tests use the RandomStream default method that rejects 0.0.\n");
+        out.append("- nextInt(i, j) and nextLong(i, j) measure bounded public API methods, including range conversion.\n");
+        out.append("- These are not raw int or raw 64-bit output speed tests.\n");
+        out.append("- Final sink values are checksums used to prevent dead-code elimination. Signed overflow is possible for longSink.\n");
+        out.append("- Java LXM generators are benchmarked through the public java.util.random.RandomGenerator API.\n\n");
+
+        out.append("Method conventions:\n");
+        out.append("- MWC64k2a2 and MWC64k3a2 nextDouble(): values are in [0, 1); 0.0 is possible and 1.0 is excluded.\n");
+        out.append("- MWC64k2a2 and MWC64k3a2 nextDouble(): the top 53 bits of the 64-bit output are multiplied by 2^(-53).\n");
+        out.append("- MWC64k2a2 and MWC64k3a2 nextDoubleNonzero(): values are in (0, 1); 0.0 is rejected.\n");
+        out.append("- MRG32k3a and LFSR258 nextDouble(): standard SSJ implementations return values in (0, 1).\n");
+        out.append("- Java LXM nextDouble(): values are in [0, 1); 0.0 is possible and 1.0 is excluded.\n");
+        out.append("- SSJ-style nextInt(i, j) and nextLong(i, j): inclusive bounds [i, j].\n");
+        out.append("- MWC64k2a2 and MWC64k3a2 nextLong(i, j): use nextNumber() directly with rejection sampling.\n");
+        out.append("- Java nextInt(origin, bound) and nextLong(origin, bound): exclusive upper bound [origin, bound).\n");
+        out.append("- For Java integer and long ranges, this benchmark uses j + 1 as the exclusive upper bound.\n\n");
+
+        out.append("============================================================\n");
+        out.append("nextDouble() and nextDoubleNonzero() speed\n");
+        out.append("Mean is computed over timed values only. Expected mean is close to 0.5.\n");
+        out.append("============================================================\n");
+
+        benchmarkMRG32k3aNextDouble(out);
+        benchmarkLFSR258NextDouble(out);
+        benchmarkMWC64k2a2NextDouble(out);
+        benchmarkMWC64k2a2NextDoubleNonzero(out);
+        benchmarkMWC64k3a2NextDouble(out);
+        benchmarkMWC64k3a2NextDoubleNonzero(out);
+        benchmarkL64X128StarStarRandomNextDouble(out);
+        benchmarkL64X128MixRandomNextDouble(out);
+        benchmarkL64X256MixRandomNextDouble(out);
+        benchmarkL64X1024MixRandomNextDouble(out);
+
+        out.append("\n");
+        out.append("============================================================\n");
+        out.append("nextInt(i, j) speed\n");
+        out.append("SSJ-style range: [").append(INT_I).append(", ").append(INT_J).append("]\n");
+        out.append("Java range: [").append(INT_I).append(", ").append(INT_J + 1).append(")\n");
+        out.append("Mean is computed over timed values only. Expected mean is close to ")
+        .append(String.format(Locale.US, "%.0f", (INT_I + INT_J) / 2.0)).append(".\n");
+        out.append("============================================================\n");
+        benchmarkMWC64k2a2NextInt(out);
+        benchmarkMWC64k3a2NextInt(out);
+        benchmarkMRG32k3aNextInt(out);
+        benchmarkLFSR258NextInt(out);
+        benchmarkL64X128StarStarRandomNextInt(out);
+        benchmarkL64X128MixRandomNextInt(out);
+        benchmarkL64X256MixRandomNextInt(out);
+        benchmarkL64X1024MixRandomNextInt(out);
+
+        out.append("\n");
+        out.append("============================================================\n");
+        out.append("nextLong(i, j) speed\n");
+        out.append("SSJ-style range: [").append(LONG_I).append(", ").append(LONG_J).append("]\n");
+        out.append("Java range: [").append(LONG_I).append(", ").append(LONG_J + 1L).append(")\n");
+        out.append("Mean is computed over timed values only. Expected mean is close to ")
+        .append(String.format(Locale.US, "%.0f", (LONG_I + LONG_J) / 2.0)).append(".\n");
+        out.append("============================================================\n");
+        benchmarkMWC64k2a2NextLong(out);
+        benchmarkMWC64k3a2NextLong(out);
+        benchmarkMRG32k3aNextLong(out);
+        benchmarkLFSR258NextLong(out);
+        benchmarkL64X128StarStarRandomNextLong(out);
+        benchmarkL64X128MixRandomNextLong(out);
+        benchmarkL64X256MixRandomNextLong(out);
+        benchmarkL64X1024MixRandomNextLong(out);
+
+        out.append("\n");
+        out.append("Final checksums, used to prevent dead-code elimination:\n");
+        out.append("doubleSink = ").append(doubleSink).append("\n");
+        out.append("intSink    = ").append(intSink).append("\n");
+        out.append("longSink   = ").append(longSink).append("\n");
+
+        System.out.println(out);
+
+        if (WRITE_FILE) {
+            FileWriter writer = new FileWriter(output_file);
+            writer.write(out.toString());
+            writer.close();
+        }
+    }
+
+    private static String formatTime(double seconds) {
+        return String.format(Locale.US, "%.4f", seconds);
+    }
+
+    private static String formatMean(double mean) {
+        return String.format(Locale.US, "%.6f", mean);
+    }
+
+    private static void benchmarkMWC64k2a2NextDouble(StringBuilder out) {
+        out.append("\nMWC64k2a2 nextDouble()\n");
+        out.append("Convention: values are in [0, 1); 0.0 is possible and 1.0 is excluded.\n");
+
+        MWC64k2a2 gen = new MWC64k2a2();
+        gen.resetStartStream();
+
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            double sum = 0.0;
+            for (int i = 0; i < M; i++)
+                sum += gen.nextDouble();
+            doubleSink += sum;
+        }
+
+        double totalTime = 0.0;
+        double totalSum = 0.0;
+
+        for (int run = 0; run < TIMED_RUNS; run++) {
+            double sum = 0.0;
+
+            long start = System.nanoTime();
+            for (int i = 0; i < M; i++)
+                sum += gen.nextDouble();
+            long end = System.nanoTime();
+
+            totalTime += (end - start) * 1.0e-9;
+            totalSum += sum;
+            doubleSink += sum;
+        }
+
+        out.append("Warmup: ").append(WARMUP_RUNS).append(" run of ")
+           .append(M_LABEL).append(" calls, excluded.\n");
+        out.append("Average time of ").append(TIMED_RUNS).append(" timed runs, each with ")
+           .append(M_LABEL).append(" calls: ").append(formatTime(totalTime / TIMED_RUNS)).append(" s\n");
+        out.append("Mean over ").append(TIMED_RUNS).append(" * ").append(M_LABEL)
+           .append(" timed values: ").append(formatMean(totalSum / ((double) TIMED_RUNS * M))).append("\n");
+    }
+
+    private static void benchmarkMWC64k2a2NextDoubleNonzero(StringBuilder out) {
+        out.append("\nMWC64k2a2 nextDoubleNonzero()\n");
+        out.append("Convention: values are in (0, 1); 0.0 is rejected by nextDoubleNonzero().\n");
+
+        MWC64k2a2 gen = new MWC64k2a2();
+        gen.resetStartStream();
+
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            double sum = 0.0;
+            for (int i = 0; i < M; i++)
+                sum += gen.nextDoubleNonzero();
+            doubleSink += sum;
+        }
+
+        double totalTime = 0.0;
+        double totalSum = 0.0;
+
+        for (int run = 0; run < TIMED_RUNS; run++) {
+            double sum = 0.0;
+
+            long start = System.nanoTime();
+            for (int i = 0; i < M; i++)
+                sum += gen.nextDoubleNonzero();
+            long end = System.nanoTime();
+
+            totalTime += (end - start) * 1.0e-9;
+            totalSum += sum;
+            doubleSink += sum;
+        }
+
+        out.append("Warmup: ").append(WARMUP_RUNS).append(" run of ")
+           .append(M_LABEL).append(" calls, excluded.\n");
+        out.append("Average time of ").append(TIMED_RUNS).append(" timed runs, each with ")
+           .append(M_LABEL).append(" calls: ").append(formatTime(totalTime / TIMED_RUNS)).append(" s\n");
+        out.append("Mean over ").append(TIMED_RUNS).append(" * ").append(M_LABEL)
+           .append(" timed values: ").append(formatMean(totalSum / ((double) TIMED_RUNS * M))).append("\n");
+    }
+
+    private static void benchmarkMWC64k3a2NextDouble(StringBuilder out) {
+        out.append("\nMWC64k3a2 nextDouble()\n");
+        out.append("Convention: values are in [0, 1); 0.0 is possible and 1.0 is excluded.\n");
+
+        MWC64k3a2 gen = new MWC64k3a2();
+        gen.resetStartStream();
+
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            double sum = 0.0;
+            for (int i = 0; i < M; i++)
+                sum += gen.nextDouble();
+            doubleSink += sum;
+        }
+
+        double totalTime = 0.0;
+        double totalSum = 0.0;
+
+        for (int run = 0; run < TIMED_RUNS; run++) {
+            double sum = 0.0;
+
+            long start = System.nanoTime();
+            for (int i = 0; i < M; i++)
+                sum += gen.nextDouble();
+            long end = System.nanoTime();
+
+            totalTime += (end - start) * 1.0e-9;
+            totalSum += sum;
+            doubleSink += sum;
+        }
+
+        out.append("Warmup: ").append(WARMUP_RUNS).append(" run of ")
+           .append(M_LABEL).append(" calls, excluded.\n");
+        out.append("Average time of ").append(TIMED_RUNS).append(" timed runs, each with ")
+           .append(M_LABEL).append(" calls: ").append(formatTime(totalTime / TIMED_RUNS)).append(" s\n");
+        out.append("Mean over ").append(TIMED_RUNS).append(" * ").append(M_LABEL)
+           .append(" timed values: ").append(formatMean(totalSum / ((double) TIMED_RUNS * M))).append("\n");
+    }
+
+    private static void benchmarkMWC64k3a2NextDoubleNonzero(StringBuilder out) {
+        out.append("\nMWC64k3a2 nextDoubleNonzero()\n");
+        out.append("Convention: values are in (0, 1); 0.0 is rejected by nextDoubleNonzero().\n");
+
+        MWC64k3a2 gen = new MWC64k3a2();
+        gen.resetStartStream();
+
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            double sum = 0.0;
+            for (int i = 0; i < M; i++)
+                sum += gen.nextDoubleNonzero();
+            doubleSink += sum;
+        }
+
+        double totalTime = 0.0;
+        double totalSum = 0.0;
+
+        for (int run = 0; run < TIMED_RUNS; run++) {
+            double sum = 0.0;
+
+            long start = System.nanoTime();
+            for (int i = 0; i < M; i++)
+                sum += gen.nextDoubleNonzero();
+            long end = System.nanoTime();
+
+            totalTime += (end - start) * 1.0e-9;
+            totalSum += sum;
+            doubleSink += sum;
+        }
+
+        out.append("Warmup: ").append(WARMUP_RUNS).append(" run of ")
+           .append(M_LABEL).append(" calls, excluded.\n");
+        out.append("Average time of ").append(TIMED_RUNS).append(" timed runs, each with ")
+           .append(M_LABEL).append(" calls: ").append(formatTime(totalTime / TIMED_RUNS)).append(" s\n");
+        out.append("Mean over ").append(TIMED_RUNS).append(" * ").append(M_LABEL)
+           .append(" timed values: ").append(formatMean(totalSum / ((double) TIMED_RUNS * M))).append("\n");
+    }
+
+    private static void benchmarkMRG32k3aNextDouble(StringBuilder out) {
+        out.append("\nMRG32k3a nextDouble()\n");
+        out.append("Convention: standard SSJ implementation returns values in (0, 1).\n");
+
+        MRG32k3a gen = new MRG32k3a();
+        gen.resetStartStream();
+
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            double sum = 0.0;
+            for (int i = 0; i < M; i++)
+                sum += gen.nextDouble();
+            doubleSink += sum;
+        }
+
+        double totalTime = 0.0;
+        double totalSum = 0.0;
+
+        for (int run = 0; run < TIMED_RUNS; run++) {
+            double sum = 0.0;
+
+            long start = System.nanoTime();
+            for (int i = 0; i < M; i++)
+                sum += gen.nextDouble();
+            long end = System.nanoTime();
+
+            totalTime += (end - start) * 1.0e-9;
+            totalSum += sum;
+            doubleSink += sum;
+        }
+
+        out.append("Warmup: ").append(WARMUP_RUNS).append(" run of ")
+           .append(M_LABEL).append(" calls, excluded.\n");
+        out.append("Average time of ").append(TIMED_RUNS).append(" timed runs, each with ")
+           .append(M_LABEL).append(" calls: ").append(formatTime(totalTime / TIMED_RUNS)).append(" s\n");
+        out.append("Mean over ").append(TIMED_RUNS).append(" * ").append(M_LABEL)
+           .append(" timed values: ").append(formatMean(totalSum / ((double) TIMED_RUNS * M))).append("\n");
+    }
+
+    private static void benchmarkLFSR258NextDouble(StringBuilder out) {
+        out.append("\nLFSR258 nextDouble()\n");
+        out.append("Convention: standard SSJ implementation returns values in (0, 1).\n");
+
+        LFSR258 gen = new LFSR258();
+        gen.resetStartStream();
+
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            double sum = 0.0;
+            for (int i = 0; i < M; i++)
+                sum += gen.nextDouble();
+            doubleSink += sum;
+        }
+
+        double totalTime = 0.0;
+        double totalSum = 0.0;
+
+        for (int run = 0; run < TIMED_RUNS; run++) {
+            double sum = 0.0;
+
+            long start = System.nanoTime();
+            for (int i = 0; i < M; i++)
+                sum += gen.nextDouble();
+            long end = System.nanoTime();
+
+            totalTime += (end - start) * 1.0e-9;
+            totalSum += sum;
+            doubleSink += sum;
+        }
+
+        out.append("Warmup: ").append(WARMUP_RUNS).append(" run of ")
+           .append(M_LABEL).append(" calls, excluded.\n");
+        out.append("Average time of ").append(TIMED_RUNS).append(" timed runs, each with ")
+           .append(M_LABEL).append(" calls: ").append(formatTime(totalTime / TIMED_RUNS)).append(" s\n");
+        out.append("Mean over ").append(TIMED_RUNS).append(" * ").append(M_LABEL)
+           .append(" timed values: ").append(formatMean(totalSum / ((double) TIMED_RUNS * M))).append("\n");
+    }
+
+    private static void benchmarkL64X128StarStarRandomNextDouble(StringBuilder out) {
+        out.append("\nL64X128StarStarRandom nextDouble()\n");
+        out.append("Convention: java.util.random nextDouble() returns values in [0, 1).\n");
+
+        RandomGeneratorFactory<RandomGenerator> factory =
+                RandomGeneratorFactory.of(JAVA_L64X128_STARSTAR);
+        RandomGenerator gen = factory.create(JAVA_SEED);
+
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            double sum = 0.0;
+            for (int i = 0; i < M; i++)
+                sum += gen.nextDouble();
+            doubleSink += sum;
+        }
+
+        double totalTime = 0.0;
+        double totalSum = 0.0;
+
+        for (int run = 0; run < TIMED_RUNS; run++) {
+            double sum = 0.0;
+
+            long start = System.nanoTime();
+            for (int i = 0; i < M; i++)
+                sum += gen.nextDouble();
+            long end = System.nanoTime();
+
+            totalTime += (end - start) * 1.0e-9;
+            totalSum += sum;
+            doubleSink += sum;
+        }
+
+        out.append("Warmup: ").append(WARMUP_RUNS).append(" run of ")
+           .append(M_LABEL).append(" calls, excluded.\n");
+        out.append("Average time of ").append(TIMED_RUNS).append(" timed runs, each with ")
+           .append(M_LABEL).append(" calls: ").append(formatTime(totalTime / TIMED_RUNS)).append(" s\n");
+        out.append("Mean over ").append(TIMED_RUNS).append(" * ").append(M_LABEL)
+           .append(" timed values: ").append(formatMean(totalSum / ((double) TIMED_RUNS * M))).append("\n");
+    }
+
+    private static void benchmarkL64X128MixRandomNextDouble(StringBuilder out) {
+        out.append("\nL64X128MixRandom nextDouble()\n");
+        out.append("Convention: java.util.random nextDouble() returns values in [0, 1).\n");
+
+        RandomGeneratorFactory<RandomGenerator> factory =
+                RandomGeneratorFactory.of(JAVA_L64X128_MIX);
+        RandomGenerator gen = factory.create(JAVA_SEED);
+
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            double sum = 0.0;
+            for (int i = 0; i < M; i++)
+                sum += gen.nextDouble();
+            doubleSink += sum;
+        }
+
+        double totalTime = 0.0;
+        double totalSum = 0.0;
+
+        for (int run = 0; run < TIMED_RUNS; run++) {
+            double sum = 0.0;
+
+            long start = System.nanoTime();
+            for (int i = 0; i < M; i++)
+                sum += gen.nextDouble();
+            long end = System.nanoTime();
+
+            totalTime += (end - start) * 1.0e-9;
+            totalSum += sum;
+            doubleSink += sum;
+        }
+
+        out.append("Warmup: ").append(WARMUP_RUNS).append(" run of ")
+           .append(M_LABEL).append(" calls, excluded.\n");
+        out.append("Average time of ").append(TIMED_RUNS).append(" timed runs, each with ")
+           .append(M_LABEL).append(" calls: ").append(formatTime(totalTime / TIMED_RUNS)).append(" s\n");
+        out.append("Mean over ").append(TIMED_RUNS).append(" * ").append(M_LABEL)
+           .append(" timed values: ").append(formatMean(totalSum / ((double) TIMED_RUNS * M))).append("\n");
+    }
+
+    private static void benchmarkL64X256MixRandomNextDouble(StringBuilder out) {
+        out.append("\nL64X256MixRandom nextDouble()\n");
+        out.append("Convention: java.util.random nextDouble() returns values in [0, 1).\n");
+
+        RandomGeneratorFactory<RandomGenerator> factory =
+                RandomGeneratorFactory.of(JAVA_L64X256_MIX);
+        RandomGenerator gen = factory.create(JAVA_SEED);
+
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            double sum = 0.0;
+            for (int i = 0; i < M; i++)
+                sum += gen.nextDouble();
+            doubleSink += sum;
+        }
+
+        double totalTime = 0.0;
+        double totalSum = 0.0;
+
+        for (int run = 0; run < TIMED_RUNS; run++) {
+            double sum = 0.0;
+
+            long start = System.nanoTime();
+            for (int i = 0; i < M; i++)
+                sum += gen.nextDouble();
+            long end = System.nanoTime();
+
+            totalTime += (end - start) * 1.0e-9;
+            totalSum += sum;
+            doubleSink += sum;
+        }
+
+        out.append("Warmup: ").append(WARMUP_RUNS).append(" run of ")
+           .append(M_LABEL).append(" calls, excluded.\n");
+        out.append("Average time of ").append(TIMED_RUNS).append(" timed runs, each with ")
+           .append(M_LABEL).append(" calls: ").append(formatTime(totalTime / TIMED_RUNS)).append(" s\n");
+        out.append("Mean over ").append(TIMED_RUNS).append(" * ").append(M_LABEL)
+           .append(" timed values: ").append(formatMean(totalSum / ((double) TIMED_RUNS * M))).append("\n");
+    }
+
+    private static void benchmarkL64X1024MixRandomNextDouble(StringBuilder out) {
+        out.append("\nL64X1024MixRandom nextDouble()\n");
+        out.append("Convention: java.util.random nextDouble() returns values in [0, 1).\n");
+
+        RandomGeneratorFactory<RandomGenerator> factory =
+                RandomGeneratorFactory.of(JAVA_L64X1024_MIX);
+        RandomGenerator gen = factory.create(JAVA_SEED);
+
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            double sum = 0.0;
+            for (int i = 0; i < M; i++)
+                sum += gen.nextDouble();
+            doubleSink += sum;
+        }
+
+        double totalTime = 0.0;
+        double totalSum = 0.0;
+
+        for (int run = 0; run < TIMED_RUNS; run++) {
+            double sum = 0.0;
+
+            long start = System.nanoTime();
+            for (int i = 0; i < M; i++)
+                sum += gen.nextDouble();
+            long end = System.nanoTime();
+
+            totalTime += (end - start) * 1.0e-9;
+            totalSum += sum;
+            doubleSink += sum;
+        }
+
+        out.append("Warmup: ").append(WARMUP_RUNS).append(" run of ")
+           .append(M_LABEL).append(" calls, excluded.\n");
+        out.append("Average time of ").append(TIMED_RUNS).append(" timed runs, each with ")
+           .append(M_LABEL).append(" calls: ").append(formatTime(totalTime / TIMED_RUNS)).append(" s\n");
+        out.append("Mean over ").append(TIMED_RUNS).append(" * ").append(M_LABEL)
+           .append(" timed values: ").append(formatMean(totalSum / ((double) TIMED_RUNS * M))).append("\n");
+    }
+
+    private static void benchmarkMWC64k2a2NextInt(StringBuilder out) {
+        out.append("\nMWC64k2a2 nextInt(i, j)\n");
+        out.append("Convention: inclusive bounds [").append(INT_I).append(", ").append(INT_J).append("].\n");
+
+        MWC64k2a2 gen = new MWC64k2a2();
+        gen.resetStartStream();
+
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            long sum = 0L;
+            for (int i = 0; i < M; i++)
+                sum += gen.nextInt(INT_I, INT_J);
+            intSink += sum;
+        }
+
+        double totalTime = 0.0;
+        double totalSum = 0.0;
+
+        for (int run = 0; run < TIMED_RUNS; run++) {
+            long sum = 0L;
+
+            long start = System.nanoTime();
+            for (int i = 0; i < M; i++)
+                sum += gen.nextInt(INT_I, INT_J);
+            long end = System.nanoTime();
+
+            totalTime += (end - start) * 1.0e-9;
+            totalSum += sum;
+            intSink += sum;
+        }
+
+        out.append("Warmup: ").append(WARMUP_RUNS).append(" run of ")
+           .append(M_LABEL).append(" calls, excluded.\n");
+        out.append("Average time of ").append(TIMED_RUNS).append(" timed runs, each with ")
+           .append(M_LABEL).append(" calls: ").append(formatTime(totalTime / TIMED_RUNS)).append(" s\n");
+        out.append("Mean over ").append(TIMED_RUNS).append(" * ").append(M_LABEL)
+           .append(" timed values: ").append(formatMean(totalSum / ((double) TIMED_RUNS * M))).append("\n");
+    }
+
+    private static void benchmarkMWC64k3a2NextInt(StringBuilder out) {
+        out.append("\nMWC64k3a2 nextInt(i, j)\n");
+        out.append("Convention: inclusive bounds [").append(INT_I).append(", ").append(INT_J).append("].\n");
+
+        MWC64k3a2 gen = new MWC64k3a2();
+        gen.resetStartStream();
+
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            long sum = 0L;
+            for (int i = 0; i < M; i++)
+                sum += gen.nextInt(INT_I, INT_J);
+            intSink += sum;
+        }
+
+        double totalTime = 0.0;
+        double totalSum = 0.0;
+
+        for (int run = 0; run < TIMED_RUNS; run++) {
+            long sum = 0L;
+
+            long start = System.nanoTime();
+            for (int i = 0; i < M; i++)
+                sum += gen.nextInt(INT_I, INT_J);
+            long end = System.nanoTime();
+
+            totalTime += (end - start) * 1.0e-9;
+            totalSum += sum;
+            intSink += sum;
+        }
+
+        out.append("Warmup: ").append(WARMUP_RUNS).append(" run of ")
+           .append(M_LABEL).append(" calls, excluded.\n");
+        out.append("Average time of ").append(TIMED_RUNS).append(" timed runs, each with ")
+           .append(M_LABEL).append(" calls: ").append(formatTime(totalTime / TIMED_RUNS)).append(" s\n");
+        out.append("Mean over ").append(TIMED_RUNS).append(" * ").append(M_LABEL)
+           .append(" timed values: ").append(formatMean(totalSum / ((double) TIMED_RUNS * M))).append("\n");
+    }
+
+    private static void benchmarkMRG32k3aNextInt(StringBuilder out) {
+        out.append("\nMRG32k3a nextInt(i, j)\n");
+        out.append("Convention: inclusive bounds [").append(INT_I).append(", ").append(INT_J).append("].\n");
+
+        MRG32k3a gen = new MRG32k3a();
+        gen.resetStartStream();
+
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            long sum = 0L;
+            for (int i = 0; i < M; i++)
+                sum += gen.nextInt(INT_I, INT_J);
+            intSink += sum;
+        }
+
+        double totalTime = 0.0;
+        double totalSum = 0.0;
+
+        for (int run = 0; run < TIMED_RUNS; run++) {
+            long sum = 0L;
+
+            long start = System.nanoTime();
+            for (int i = 0; i < M; i++)
+                sum += gen.nextInt(INT_I, INT_J);
+            long end = System.nanoTime();
+
+            totalTime += (end - start) * 1.0e-9;
+            totalSum += sum;
+            intSink += sum;
+        }
+
+        out.append("Warmup: ").append(WARMUP_RUNS).append(" run of ")
+           .append(M_LABEL).append(" calls, excluded.\n");
+        out.append("Average time of ").append(TIMED_RUNS).append(" timed runs, each with ")
+           .append(M_LABEL).append(" calls: ").append(formatTime(totalTime / TIMED_RUNS)).append(" s\n");
+        out.append("Mean over ").append(TIMED_RUNS).append(" * ").append(M_LABEL)
+           .append(" timed values: ").append(formatMean(totalSum / ((double) TIMED_RUNS * M))).append("\n");
+    }
+
+    private static void benchmarkLFSR258NextInt(StringBuilder out) {
+        out.append("\nLFSR258 nextInt(i, j)\n");
+        out.append("Convention: inclusive bounds [").append(INT_I).append(", ").append(INT_J).append("].\n");
+
+        LFSR258 gen = new LFSR258();
+        gen.resetStartStream();
+
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            long sum = 0L;
+            for (int i = 0; i < M; i++)
+                sum += gen.nextInt(INT_I, INT_J);
+            intSink += sum;
+        }
+
+        double totalTime = 0.0;
+        double totalSum = 0.0;
+
+        for (int run = 0; run < TIMED_RUNS; run++) {
+            long sum = 0L;
+
+            long start = System.nanoTime();
+            for (int i = 0; i < M; i++)
+                sum += gen.nextInt(INT_I, INT_J);
+            long end = System.nanoTime();
+
+            totalTime += (end - start) * 1.0e-9;
+            totalSum += sum;
+            intSink += sum;
+        }
+
+        out.append("Warmup: ").append(WARMUP_RUNS).append(" run of ")
+           .append(M_LABEL).append(" calls, excluded.\n");
+        out.append("Average time of ").append(TIMED_RUNS).append(" timed runs, each with ")
+           .append(M_LABEL).append(" calls: ").append(formatTime(totalTime / TIMED_RUNS)).append(" s\n");
+        out.append("Mean over ").append(TIMED_RUNS).append(" * ").append(M_LABEL)
+           .append(" timed values: ").append(formatMean(totalSum / ((double) TIMED_RUNS * M))).append("\n");
+    }
+
+    private static void benchmarkL64X128StarStarRandomNextInt(StringBuilder out) {
+        out.append("\nL64X128StarStarRandom nextInt(i, j + 1)\n");
+        out.append("Convention: exclusive upper bound; Java call is nextInt(")
+           .append(INT_I).append(", ").append(INT_J + 1).append(").\n");
+
+        RandomGeneratorFactory<RandomGenerator> factory =
+                RandomGeneratorFactory.of(JAVA_L64X128_STARSTAR);
+        RandomGenerator gen = factory.create(JAVA_SEED);
+
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            long sum = 0L;
+            for (int i = 0; i < M; i++)
+                sum += gen.nextInt(INT_I, INT_J + 1);
+            intSink += sum;
+        }
+
+        double totalTime = 0.0;
+        double totalSum = 0.0;
+
+        for (int run = 0; run < TIMED_RUNS; run++) {
+            long sum = 0L;
+
+            long start = System.nanoTime();
+            for (int i = 0; i < M; i++)
+                sum += gen.nextInt(INT_I, INT_J + 1);
+            long end = System.nanoTime();
+
+            totalTime += (end - start) * 1.0e-9;
+            totalSum += sum;
+            intSink += sum;
+        }
+
+        out.append("Warmup: ").append(WARMUP_RUNS).append(" run of ")
+           .append(M_LABEL).append(" calls, excluded.\n");
+        out.append("Average time of ").append(TIMED_RUNS).append(" timed runs, each with ")
+           .append(M_LABEL).append(" calls: ").append(formatTime(totalTime / TIMED_RUNS)).append(" s\n");
+        out.append("Mean over ").append(TIMED_RUNS).append(" * ").append(M_LABEL)
+           .append(" timed values: ").append(formatMean(totalSum / ((double) TIMED_RUNS * M))).append("\n");
+    }
+
+    private static void benchmarkL64X128MixRandomNextInt(StringBuilder out) {
+        out.append("\nL64X128MixRandom nextInt(i, j + 1)\n");
+        out.append("Convention: exclusive upper bound; Java call is nextInt(")
+           .append(INT_I).append(", ").append(INT_J + 1).append(").\n");
+
+        RandomGeneratorFactory<RandomGenerator> factory =
+                RandomGeneratorFactory.of(JAVA_L64X128_MIX);
+        RandomGenerator gen = factory.create(JAVA_SEED);
+
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            long sum = 0L;
+            for (int i = 0; i < M; i++)
+                sum += gen.nextInt(INT_I, INT_J + 1);
+            intSink += sum;
+        }
+
+        double totalTime = 0.0;
+        double totalSum = 0.0;
+
+        for (int run = 0; run < TIMED_RUNS; run++) {
+            long sum = 0L;
+
+            long start = System.nanoTime();
+            for (int i = 0; i < M; i++)
+                sum += gen.nextInt(INT_I, INT_J + 1);
+            long end = System.nanoTime();
+
+            totalTime += (end - start) * 1.0e-9;
+            totalSum += sum;
+            intSink += sum;
+        }
+
+        out.append("Warmup: ").append(WARMUP_RUNS).append(" run of ")
+           .append(M_LABEL).append(" calls, excluded.\n");
+        out.append("Average time of ").append(TIMED_RUNS).append(" timed runs, each with ")
+           .append(M_LABEL).append(" calls: ").append(formatTime(totalTime / TIMED_RUNS)).append(" s\n");
+        out.append("Mean over ").append(TIMED_RUNS).append(" * ").append(M_LABEL)
+           .append(" timed values: ").append(formatMean(totalSum / ((double) TIMED_RUNS * M))).append("\n");
+    }
+
+    private static void benchmarkL64X256MixRandomNextInt(StringBuilder out) {
+        out.append("\nL64X256MixRandom nextInt(i, j + 1)\n");
+        out.append("Convention: exclusive upper bound; Java call is nextInt(")
+           .append(INT_I).append(", ").append(INT_J + 1).append(").\n");
+
+        RandomGeneratorFactory<RandomGenerator> factory =
+                RandomGeneratorFactory.of(JAVA_L64X256_MIX);
+        RandomGenerator gen = factory.create(JAVA_SEED);
+
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            long sum = 0L;
+            for (int i = 0; i < M; i++)
+                sum += gen.nextInt(INT_I, INT_J + 1);
+            intSink += sum;
+        }
+
+        double totalTime = 0.0;
+        double totalSum = 0.0;
+
+        for (int run = 0; run < TIMED_RUNS; run++) {
+            long sum = 0L;
+
+            long start = System.nanoTime();
+            for (int i = 0; i < M; i++)
+                sum += gen.nextInt(INT_I, INT_J + 1);
+            long end = System.nanoTime();
+
+            totalTime += (end - start) * 1.0e-9;
+            totalSum += sum;
+            intSink += sum;
+        }
+
+        out.append("Warmup: ").append(WARMUP_RUNS).append(" run of ")
+           .append(M_LABEL).append(" calls, excluded.\n");
+        out.append("Average time of ").append(TIMED_RUNS).append(" timed runs, each with ")
+           .append(M_LABEL).append(" calls: ").append(formatTime(totalTime / TIMED_RUNS)).append(" s\n");
+        out.append("Mean over ").append(TIMED_RUNS).append(" * ").append(M_LABEL)
+           .append(" timed values: ").append(formatMean(totalSum / ((double) TIMED_RUNS * M))).append("\n");
+    }
+
+    private static void benchmarkL64X1024MixRandomNextInt(StringBuilder out) {
+        out.append("\nL64X1024MixRandom nextInt(i, j + 1)\n");
+        out.append("Convention: exclusive upper bound; Java call is nextInt(")
+           .append(INT_I).append(", ").append(INT_J + 1).append(").\n");
+
+        RandomGeneratorFactory<RandomGenerator> factory =
+                RandomGeneratorFactory.of(JAVA_L64X1024_MIX);
+        RandomGenerator gen = factory.create(JAVA_SEED);
+
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            long sum = 0L;
+            for (int i = 0; i < M; i++)
+                sum += gen.nextInt(INT_I, INT_J + 1);
+            intSink += sum;
+        }
+
+        double totalTime = 0.0;
+        double totalSum = 0.0;
+
+        for (int run = 0; run < TIMED_RUNS; run++) {
+            long sum = 0L;
+
+            long start = System.nanoTime();
+            for (int i = 0; i < M; i++)
+                sum += gen.nextInt(INT_I, INT_J + 1);
+            long end = System.nanoTime();
+
+            totalTime += (end - start) * 1.0e-9;
+            totalSum += sum;
+            intSink += sum;
+        }
+
+        out.append("Warmup: ").append(WARMUP_RUNS).append(" run of ")
+           .append(M_LABEL).append(" calls, excluded.\n");
+        out.append("Average time of ").append(TIMED_RUNS).append(" timed runs, each with ")
+           .append(M_LABEL).append(" calls: ").append(formatTime(totalTime / TIMED_RUNS)).append(" s\n");
+        out.append("Mean over ").append(TIMED_RUNS).append(" * ").append(M_LABEL)
+           .append(" timed values: ").append(formatMean(totalSum / ((double) TIMED_RUNS * M))).append("\n");
+    }
+
+    private static void benchmarkMWC64k2a2NextLong(StringBuilder out) {
+        out.append("\nMWC64k2a2 nextLong(i, j)\n");
+        out.append("Convention: inclusive bounds [").append(LONG_I).append(", ").append(LONG_J).append("].\n");
+
+        MWC64k2a2 gen = new MWC64k2a2();
+        gen.resetStartStream();
+
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            long checksum = 0L;
+            for (int i = 0; i < M; i++)
+                checksum += gen.nextLong(LONG_I, LONG_J);
+            longSink += checksum;
+        }
+
+        double totalTime = 0.0;
+        double totalSum = 0.0;
+
+        for (int run = 0; run < TIMED_RUNS; run++) {
+            long checksum = 0L;
+            double sum = 0.0;
+
+            long start = System.nanoTime();
+            for (int i = 0; i < M; i++) {
+                long x = gen.nextLong(LONG_I, LONG_J);
+                checksum += x;
+                sum += x;
+            }
+            long end = System.nanoTime();
+
+            totalTime += (end - start) * 1.0e-9;
+            totalSum += sum;
+            longSink += checksum;
+        }
+
+        out.append("Warmup: ").append(WARMUP_RUNS).append(" run of ")
+           .append(M_LABEL).append(" calls, excluded.\n");
+        out.append("Average time of ").append(TIMED_RUNS).append(" timed runs, each with ")
+           .append(M_LABEL).append(" calls: ").append(formatTime(totalTime / TIMED_RUNS)).append(" s\n");
+        out.append("Mean over ").append(TIMED_RUNS).append(" * ").append(M_LABEL)
+           .append(" timed values: ").append(formatMean(totalSum / ((double) TIMED_RUNS * M))).append("\n");
+    }
+
+    private static void benchmarkMWC64k3a2NextLong(StringBuilder out) {
+        out.append("\nMWC64k3a2 nextLong(i, j)\n");
+        out.append("Convention: inclusive bounds [").append(LONG_I).append(", ").append(LONG_J).append("].\n");
+
+        MWC64k3a2 gen = new MWC64k3a2();
+        gen.resetStartStream();
+
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            long checksum = 0L;
+            for (int i = 0; i < M; i++)
+                checksum += gen.nextLong(LONG_I, LONG_J);
+            longSink += checksum;
+        }
+
+        double totalTime = 0.0;
+        double totalSum = 0.0;
+
+        for (int run = 0; run < TIMED_RUNS; run++) {
+            long checksum = 0L;
+            double sum = 0.0;
+
+            long start = System.nanoTime();
+            for (int i = 0; i < M; i++) {
+                long x = gen.nextLong(LONG_I, LONG_J);
+                checksum += x;
+                sum += x;
+            }
+            long end = System.nanoTime();
+
+            totalTime += (end - start) * 1.0e-9;
+            totalSum += sum;
+            longSink += checksum;
+        }
+
+        out.append("Warmup: ").append(WARMUP_RUNS).append(" run of ")
+           .append(M_LABEL).append(" calls, excluded.\n");
+        out.append("Average time of ").append(TIMED_RUNS).append(" timed runs, each with ")
+           .append(M_LABEL).append(" calls: ").append(formatTime(totalTime / TIMED_RUNS)).append(" s\n");
+        out.append("Mean over ").append(TIMED_RUNS).append(" * ").append(M_LABEL)
+           .append(" timed values: ").append(formatMean(totalSum / ((double) TIMED_RUNS * M))).append("\n");
+    }
+
+    private static void benchmarkMRG32k3aNextLong(StringBuilder out) {
+        out.append("\nMRG32k3a nextLong(i, j)\n");
+        out.append("Convention: inclusive bounds [").append(LONG_I).append(", ").append(LONG_J).append("].\n");
+
+        MRG32k3a gen = new MRG32k3a();
+        gen.resetStartStream();
+
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            long checksum = 0L;
+            for (int i = 0; i < M; i++)
+                checksum += gen.nextLong(LONG_I, LONG_J);
+            longSink += checksum;
+        }
+
+        double totalTime = 0.0;
+        double totalSum = 0.0;
+
+        for (int run = 0; run < TIMED_RUNS; run++) {
+            long checksum = 0L;
+            double sum = 0.0;
+
+            long start = System.nanoTime();
+            for (int i = 0; i < M; i++) {
+                long x = gen.nextLong(LONG_I, LONG_J);
+                checksum += x;
+                sum += x;
+            }
+            long end = System.nanoTime();
+
+            totalTime += (end - start) * 1.0e-9;
+            totalSum += sum;
+            longSink += checksum;
+        }
+
+        out.append("Warmup: ").append(WARMUP_RUNS).append(" run of ")
+           .append(M_LABEL).append(" calls, excluded.\n");
+        out.append("Average time of ").append(TIMED_RUNS).append(" timed runs, each with ")
+           .append(M_LABEL).append(" calls: ").append(formatTime(totalTime / TIMED_RUNS)).append(" s\n");
+        out.append("Mean over ").append(TIMED_RUNS).append(" * ").append(M_LABEL)
+           .append(" timed values: ").append(formatMean(totalSum / ((double) TIMED_RUNS * M))).append("\n");
+    }
+
+    private static void benchmarkLFSR258NextLong(StringBuilder out) {
+        out.append("\nLFSR258 nextLong(i, j)\n");
+        out.append("Convention: inclusive bounds [").append(LONG_I).append(", ").append(LONG_J).append("].\n");
+
+        LFSR258 gen = new LFSR258();
+        gen.resetStartStream();
+
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            long checksum = 0L;
+            for (int i = 0; i < M; i++)
+                checksum += gen.nextLong(LONG_I, LONG_J);
+            longSink += checksum;
+        }
+
+        double totalTime = 0.0;
+        double totalSum = 0.0;
+
+        for (int run = 0; run < TIMED_RUNS; run++) {
+            long checksum = 0L;
+            double sum = 0.0;
+
+            long start = System.nanoTime();
+            for (int i = 0; i < M; i++) {
+                long x = gen.nextLong(LONG_I, LONG_J);
+                checksum += x;
+                sum += x;
+            }
+            long end = System.nanoTime();
+
+            totalTime += (end - start) * 1.0e-9;
+            totalSum += sum;
+            longSink += checksum;
+        }
+
+        out.append("Warmup: ").append(WARMUP_RUNS).append(" run of ")
+           .append(M_LABEL).append(" calls, excluded.\n");
+        out.append("Average time of ").append(TIMED_RUNS).append(" timed runs, each with ")
+           .append(M_LABEL).append(" calls: ").append(formatTime(totalTime / TIMED_RUNS)).append(" s\n");
+        out.append("Mean over ").append(TIMED_RUNS).append(" * ").append(M_LABEL)
+           .append(" timed values: ").append(formatMean(totalSum / ((double) TIMED_RUNS * M))).append("\n");
+    }
+
+    private static void benchmarkL64X128StarStarRandomNextLong(StringBuilder out) {
+        out.append("\nL64X128StarStarRandom nextLong(i, j + 1)\n");
+        out.append("Convention: exclusive upper bound; Java call is nextLong(")
+           .append(LONG_I).append(", ").append(LONG_J + 1L).append(").\n");
+
+        RandomGeneratorFactory<RandomGenerator> factory =
+                RandomGeneratorFactory.of(JAVA_L64X128_STARSTAR);
+        RandomGenerator gen = factory.create(JAVA_SEED);
+
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            long checksum = 0L;
+            for (int i = 0; i < M; i++)
+                checksum += gen.nextLong(LONG_I, LONG_J + 1L);
+            longSink += checksum;
+        }
+
+        double totalTime = 0.0;
+        double totalSum = 0.0;
+
+        for (int run = 0; run < TIMED_RUNS; run++) {
+            long checksum = 0L;
+            double sum = 0.0;
+
+            long start = System.nanoTime();
+            for (int i = 0; i < M; i++) {
+                long x = gen.nextLong(LONG_I, LONG_J + 1L);
+                checksum += x;
+                sum += x;
+            }
+            long end = System.nanoTime();
+
+            totalTime += (end - start) * 1.0e-9;
+            totalSum += sum;
+            longSink += checksum;
+        }
+
+        out.append("Warmup: ").append(WARMUP_RUNS).append(" run of ")
+           .append(M_LABEL).append(" calls, excluded.\n");
+        out.append("Average time of ").append(TIMED_RUNS).append(" timed runs, each with ")
+           .append(M_LABEL).append(" calls: ").append(formatTime(totalTime / TIMED_RUNS)).append(" s\n");
+        out.append("Mean over ").append(TIMED_RUNS).append(" * ").append(M_LABEL)
+           .append(" timed values: ").append(formatMean(totalSum / ((double) TIMED_RUNS * M))).append("\n");
+    }
+
+    private static void benchmarkL64X128MixRandomNextLong(StringBuilder out) {
+        out.append("\nL64X128MixRandom nextLong(i, j + 1)\n");
+        out.append("Convention: exclusive upper bound; Java call is nextLong(")
+           .append(LONG_I).append(", ").append(LONG_J + 1L).append(").\n");
+
+        RandomGeneratorFactory<RandomGenerator> factory =
+                RandomGeneratorFactory.of(JAVA_L64X128_MIX);
+        RandomGenerator gen = factory.create(JAVA_SEED);
+
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            long checksum = 0L;
+            for (int i = 0; i < M; i++)
+                checksum += gen.nextLong(LONG_I, LONG_J + 1L);
+            longSink += checksum;
+        }
+
+        double totalTime = 0.0;
+        double totalSum = 0.0;
+
+        for (int run = 0; run < TIMED_RUNS; run++) {
+            long checksum = 0L;
+            double sum = 0.0;
+
+            long start = System.nanoTime();
+            for (int i = 0; i < M; i++) {
+                long x = gen.nextLong(LONG_I, LONG_J + 1L);
+                checksum += x;
+                sum += x;
+            }
+            long end = System.nanoTime();
+
+            totalTime += (end - start) * 1.0e-9;
+            totalSum += sum;
+            longSink += checksum;
+        }
+
+        out.append("Warmup: ").append(WARMUP_RUNS).append(" run of ")
+           .append(M_LABEL).append(" calls, excluded.\n");
+        out.append("Average time of ").append(TIMED_RUNS).append(" timed runs, each with ")
+           .append(M_LABEL).append(" calls: ").append(formatTime(totalTime / TIMED_RUNS)).append(" s\n");
+        out.append("Mean over ").append(TIMED_RUNS).append(" * ").append(M_LABEL)
+           .append(" timed values: ").append(formatMean(totalSum / ((double) TIMED_RUNS * M))).append("\n");
+    }
+
+    private static void benchmarkL64X256MixRandomNextLong(StringBuilder out) {
+        out.append("\nL64X256MixRandom nextLong(i, j + 1)\n");
+        out.append("Convention: exclusive upper bound; Java call is nextLong(")
+           .append(LONG_I).append(", ").append(LONG_J + 1L).append(").\n");
+
+        RandomGeneratorFactory<RandomGenerator> factory =
+                RandomGeneratorFactory.of(JAVA_L64X256_MIX);
+        RandomGenerator gen = factory.create(JAVA_SEED);
+
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            long checksum = 0L;
+            for (int i = 0; i < M; i++)
+                checksum += gen.nextLong(LONG_I, LONG_J + 1L);
+            longSink += checksum;
+        }
+
+        double totalTime = 0.0;
+        double totalSum = 0.0;
+
+        for (int run = 0; run < TIMED_RUNS; run++) {
+            long checksum = 0L;
+            double sum = 0.0;
+
+            long start = System.nanoTime();
+            for (int i = 0; i < M; i++) {
+                long x = gen.nextLong(LONG_I, LONG_J + 1L);
+                checksum += x;
+                sum += x;
+            }
+            long end = System.nanoTime();
+
+            totalTime += (end - start) * 1.0e-9;
+            totalSum += sum;
+            longSink += checksum;
+        }
+
+        out.append("Warmup: ").append(WARMUP_RUNS).append(" run of ")
+           .append(M_LABEL).append(" calls, excluded.\n");
+        out.append("Average time of ").append(TIMED_RUNS).append(" timed runs, each with ")
+           .append(M_LABEL).append(" calls: ").append(formatTime(totalTime / TIMED_RUNS)).append(" s\n");
+        out.append("Mean over ").append(TIMED_RUNS).append(" * ").append(M_LABEL)
+           .append(" timed values: ").append(formatMean(totalSum / ((double) TIMED_RUNS * M))).append("\n");
+    }
+
+    private static void benchmarkL64X1024MixRandomNextLong(StringBuilder out) {
+        out.append("\nL64X1024MixRandom nextLong(i, j + 1)\n");
+        out.append("Convention: exclusive upper bound; Java call is nextLong(")
+           .append(LONG_I).append(", ").append(LONG_J + 1L).append(").\n");
+
+        RandomGeneratorFactory<RandomGenerator> factory =
+                RandomGeneratorFactory.of(JAVA_L64X1024_MIX);
+        RandomGenerator gen = factory.create(JAVA_SEED);
+
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            long checksum = 0L;
+            for (int i = 0; i < M; i++)
+                checksum += gen.nextLong(LONG_I, LONG_J + 1L);
+            longSink += checksum;
+        }
+
+        double totalTime = 0.0;
+        double totalSum = 0.0;
+
+        for (int run = 0; run < TIMED_RUNS; run++) {
+            long checksum = 0L;
+            double sum = 0.0;
+
+            long start = System.nanoTime();
+            for (int i = 0; i < M; i++) {
+                long x = gen.nextLong(LONG_I, LONG_J + 1L);
+                checksum += x;
+                sum += x;
+            }
+            long end = System.nanoTime();
+
+            totalTime += (end - start) * 1.0e-9;
+            totalSum += sum;
+            longSink += checksum;
+        }
+
+        out.append("Warmup: ").append(WARMUP_RUNS).append(" run of ")
+           .append(M_LABEL).append(" calls, excluded.\n");
+        out.append("Average time of ").append(TIMED_RUNS).append(" timed runs, each with ")
+           .append(M_LABEL).append(" calls: ").append(formatTime(totalTime / TIMED_RUNS)).append(" s\n");
+        out.append("Mean over ").append(TIMED_RUNS).append(" * ").append(M_LABEL)
+           .append(" timed values: ").append(formatMean(totalSum / ((double) TIMED_RUNS * M))).append("\n");
+    }
+}

--- a/src/main/docs/examples/rngexperiments/RngJumpSpeed.java
+++ b/src/main/docs/examples/rngexperiments/RngJumpSpeed.java
@@ -1,0 +1,287 @@
+package rngexperiments;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Locale;
+import java.util.random.RandomGenerator;
+import java.util.random.RandomGeneratorFactory;
+
+import umontreal.ssj.rng.MWC64k2a2;
+import umontreal.ssj.rng.MWC64k3a2;
+import umontreal.ssj.rng.MRG32k3a;
+import umontreal.ssj.rng.LFSR258;
+
+/**
+ * Fixed jump speed benchmark.
+ *
+ * Compared operations:
+ *
+ * SSJ-style generators:
+ * resetNextSubstream()
+ *
+ * Java jumpable generators:
+ * JumpableGenerator.jump()
+ *
+ * This is a conceptual comparison. SSJ substream jumps and Java jump()
+ * do not necessarily use the same jump distance.
+ *
+ * The benchmark uses one warmup run followed by timed runs. Each generator is
+ * reset or recreated once before warmup, then timed runs continue from the state
+ * reached after warmup.
+ */
+public class RngJumpSpeed {
+
+    static final boolean WRITE_FILE = true;
+
+    static final int M = 1_000_000;
+    static final String M_LABEL = "1e6";
+
+    static final int WARMUP_RUNS = 1;
+    static final int TIMED_RUNS = 5;
+
+    static final long JAVA_SEED = 12345L;
+
+    static final String JAVA_XOROSHIRO128_PP = "Xoroshiro128PlusPlus";
+    static final String JAVA_XOSHIRO256_PP = "Xoshiro256PlusPlus";
+
+    static double sink = 0.0;
+
+    public static void main(String[] args) throws IOException {
+        StringBuilder out = new StringBuilder();
+        String outputFile = "/home/otman/Documents/GitHub/Data/o-MWC-test/RngJumpSpeedSub.res";
+
+        out.append("RNG fixed jump speed benchmark\n");
+        out.append("M = ").append(M_LABEL).append(" jumps per run (").append(M).append(")\n");
+        out.append("Warmup runs = ").append(WARMUP_RUNS).append(" run of ")
+           .append(M_LABEL).append(" jumps, excluded from timing result\n");
+        out.append("Timed runs = ").append(TIMED_RUNS).append(" runs of ")
+           .append(M_LABEL).append(" jumps\n");
+        out.append("Reported time = average time per jump over ").append(TIMED_RUNS)
+           .append(" timed runs, each with ").append(M_LABEL).append(" jumps\n\n");
+
+        out.append("Benchmark notes:\n");
+        out.append("- SSJ-style generators use resetNextSubstream().\n");
+        out.append("- Java generators use RandomGenerator.JumpableGenerator.jump().\n");
+        out.append("- This is a conceptual comparison only; the jump distances are not equal.\n");
+        out.append("- One nextDouble() or nextLong() call is made after each run and added to a sink to keep the final state observable.\n");
+        out.append("- The output reports only the average time per jump.\n\n");
+
+        out.append("Generators:\n");
+        out.append("- MWC64k2a2\n");
+        out.append("- MWC64k3a2\n");
+        out.append("- MRG32k3a\n");
+        out.append("- LFSR258\n");
+        out.append("- Xoroshiro128PlusPlus\n");
+        out.append("- Xoshiro256PlusPlus\n\n");
+
+        out.append("============================================================\n");
+        out.append("Fixed jump speed\n");
+        out.append("============================================================\n");
+
+        benchmarkMWC64k2a2NextSubstream(out);
+        benchmarkMWC64k3a2NextSubstream(out);
+        benchmarkMRG32k3aNextSubstream(out);
+        benchmarkLFSR258NextSubstream(out);
+
+        benchmarkJavaJump(out, JAVA_XOROSHIRO128_PP);
+        benchmarkJavaJump(out, JAVA_XOSHIRO256_PP);
+
+        out.append("\nFinal sink, used to prevent dead-code elimination:\n");
+        out.append("sink = ").append(sink).append("\n");
+
+        System.out.println(out);
+
+        if (WRITE_FILE) {
+            FileWriter writer = new FileWriter(outputFile);
+            writer.write(out.toString());
+            writer.close();
+        }
+    }
+
+    private static String formatNs(double ns) {
+        return String.format(Locale.US, "%.3f", ns);
+    }
+
+    private static String formatJumpDistance(double distance) {
+        if (distance > 0.0) {
+            int exponent = (int) Math.round(Math.log(distance) / Math.log(2.0));
+            double power = Math.pow(2.0, exponent);
+
+            if (Double.compare(power, distance) == 0)
+                return "2**" + exponent;
+        }
+
+        return String.format(Locale.US, "%.0f", distance);
+    }
+
+    private static void benchmarkMWC64k2a2NextSubstream(StringBuilder out) {
+        out.append("\nMWC64k2a2 resetNextSubstream()\n");
+        out.append("Jump distance: 2**62\n");
+
+        MWC64k2a2 gen = new MWC64k2a2();
+        gen.resetStartStream();
+
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            for (int i = 0; i < M; i++)
+                gen.resetNextSubstream();
+            sink += gen.nextDouble();
+        }
+
+        double totalTime = 0.0;
+
+        for (int run = 0; run < TIMED_RUNS; run++) {
+            long start = System.nanoTime();
+
+            for (int i = 0; i < M; i++)
+                gen.resetNextSubstream();
+
+            long end = System.nanoTime();
+
+            totalTime += (end - start) * 1.0e-9;
+            sink += gen.nextDouble();
+        }
+
+        printResult(out, totalTime);
+    }
+
+    private static void benchmarkMWC64k3a2NextSubstream(StringBuilder out) {
+        out.append("\nMWC64k3a2 resetNextSubstream()\n");
+        out.append("Jump distance: 2**118\n");
+
+        MWC64k3a2 gen = new MWC64k3a2();
+        gen.resetStartStream();
+
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            for (int i = 0; i < M; i++)
+                gen.resetNextSubstream();
+            sink += gen.nextDouble();
+        }
+
+        double totalTime = 0.0;
+
+        for (int run = 0; run < TIMED_RUNS; run++) {
+            long start = System.nanoTime();
+
+            for (int i = 0; i < M; i++)
+                gen.resetNextSubstream();
+
+            long end = System.nanoTime();
+
+            totalTime += (end - start) * 1.0e-9;
+            sink += gen.nextDouble();
+        }
+
+        printResult(out, totalTime);
+    }
+
+    private static void benchmarkMRG32k3aNextSubstream(StringBuilder out) {
+        out.append("\nMRG32k3a resetNextSubstream()\n");
+        out.append("Jump distance: 2**76\n");
+
+        MRG32k3a gen = new MRG32k3a();
+        gen.resetStartStream();
+
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            for (int i = 0; i < M; i++)
+                gen.resetNextSubstream();
+            sink += gen.nextDouble();
+        }
+
+        double totalTime = 0.0;
+
+        for (int run = 0; run < TIMED_RUNS; run++) {
+            long start = System.nanoTime();
+
+            for (int i = 0; i < M; i++)
+                gen.resetNextSubstream();
+
+            long end = System.nanoTime();
+
+            totalTime += (end - start) * 1.0e-9;
+            sink += gen.nextDouble();
+        }
+
+        printResult(out, totalTime);
+    }
+
+    private static void benchmarkLFSR258NextSubstream(StringBuilder out) {
+        out.append("\nLFSR258 resetNextSubstream()\n");
+        out.append("Jump distance: 2**100\n");
+
+        LFSR258 gen = new LFSR258();
+        gen.resetStartStream();
+
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            for (int i = 0; i < M; i++)
+                gen.resetNextSubstream();
+            sink += gen.nextDouble();
+        }
+
+        double totalTime = 0.0;
+
+        for (int run = 0; run < TIMED_RUNS; run++) {
+            long start = System.nanoTime();
+
+            for (int i = 0; i < M; i++)
+                gen.resetNextSubstream();
+
+            long end = System.nanoTime();
+
+            totalTime += (end - start) * 1.0e-9;
+            sink += gen.nextDouble();
+        }
+
+        printResult(out, totalTime);
+    }
+
+    private static void benchmarkJavaJump(StringBuilder out, String algorithm) {
+        out.append("\n").append(algorithm).append(" jump()\n");
+
+        RandomGenerator gen0 = RandomGeneratorFactory.of(algorithm).create(JAVA_SEED);
+
+        if (!(gen0 instanceof RandomGenerator.JumpableGenerator)) {
+            out.append("Skipped: this generator does not implement JumpableGenerator.\n");
+            return;
+        }
+
+        RandomGenerator.JumpableGenerator gen =
+                (RandomGenerator.JumpableGenerator) gen0;
+
+        out.append("Jump distance reported by Java: ")
+           .append(formatJumpDistance(gen.jumpDistance()))
+           .append("\n");
+
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            for (int i = 0; i < M; i++)
+                gen.jump();
+            sink += gen.nextLong();
+        }
+
+        double totalTime = 0.0;
+
+        for (int run = 0; run < TIMED_RUNS; run++) {
+            long start = System.nanoTime();
+
+            for (int i = 0; i < M; i++)
+                gen.jump();
+
+            long end = System.nanoTime();
+
+            totalTime += (end - start) * 1.0e-9;
+            sink += gen.nextLong();
+        }
+
+        printResult(out, totalTime);
+    }
+
+    private static void printResult(StringBuilder out, double totalTime) {
+        double averageRunSeconds = totalTime / TIMED_RUNS;
+        double nsPerJump = averageRunSeconds * 1.0e9 / M;
+
+        out.append("Warmup: ").append(WARMUP_RUNS).append(" run of ")
+           .append(M_LABEL).append(" jumps, excluded.\n");
+        out.append("Average time per jump over ").append(TIMED_RUNS)
+           .append(" timed runs, each with ").append(M_LABEL).append(" jumps: ")
+           .append(formatNs(nsPerJump)).append(" ns\n");
+    }
+}

--- a/src/main/docs/examples/rngexperiments/RngStreamJumpSpeed.java
+++ b/src/main/docs/examples/rngexperiments/RngStreamJumpSpeed.java
@@ -1,0 +1,290 @@
+package rngexperiments;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Locale;
+import java.util.random.RandomGenerator;
+import java.util.random.RandomGeneratorFactory;
+
+import umontreal.ssj.rng.MWC64k2a2;
+import umontreal.ssj.rng.MWC64k3a2;
+import umontreal.ssj.rng.MRG32k3a;
+import umontreal.ssj.rng.LFSR258;
+
+/**
+ * Stream-level jump speed benchmark.
+ *
+ * Compared operations:
+ *
+ * SSJ-style generators:
+ * new stream creation through the constructor
+ *
+ * Java leapable generators:
+ * LeapableGenerator.leap()
+ *
+ * This is a conceptual comparison only. The jump distances are not necessarily
+ * equal, and SSJ-style generators do not expose a public "next stream" jump
+ * method. For SSJ-style generators, this benchmark creates new stream
+ * instances to simulate moving to successive streams.
+ *
+ * The benchmark uses one warmup run followed by timed runs.
+ */
+public class RngStreamJumpSpeed {
+
+    static final boolean WRITE_FILE = true;
+
+    static final int M = 1_000_000;
+    static final String M_LABEL = "1e6";
+
+    static final int WARMUP_RUNS = 1;
+    static final int TIMED_RUNS = 5;
+
+    static final long JAVA_SEED = 12345L;
+
+    static final String JAVA_XOROSHIRO128_PP = "Xoroshiro128PlusPlus";
+    static final String JAVA_XOSHIRO256_PP = "Xoshiro256PlusPlus";
+
+    static double sink = 0.0;
+
+    public static void main(String[] args) throws IOException {
+        StringBuilder out = new StringBuilder();
+        String outputFile = "/home/otman/Documents/GitHub/Data/o-MWC-test/RngStreamJumpSpeed.res";
+
+        out.append("RNG stream-level jump speed benchmark\n");
+        out.append("M = ").append(M_LABEL).append(" stream operations per run (").append(M).append(")\n");
+        out.append("Warmup runs = ").append(WARMUP_RUNS).append(" run of ")
+           .append(M_LABEL).append(" stream operations, excluded from timing result\n");
+        out.append("Timed runs = ").append(TIMED_RUNS).append(" runs of ")
+           .append(M_LABEL).append(" stream operations\n");
+        out.append("Reported time = average time per stream operation over ").append(TIMED_RUNS)
+           .append(" timed runs, each with ").append(M_LABEL).append(" operations\n\n");
+
+        out.append("Benchmark notes:\n");
+        out.append("- SSJ-style generators have no public next-stream jump method.\n");
+        out.append("- For SSJ-style generators, one operation creates one new stream instance.\n");
+        out.append("- Java generators use RandomGenerator.LeapableGenerator.leap().\n");
+        out.append("- This is a conceptual comparison only; the jump distances and mechanisms are not necessarily equal.\n");
+        out.append("- SSJ-style timings include object construction and package-seed advancement.\n");
+        out.append("- Java timings measure leap() on an existing generator.\n");
+        out.append("- One nextDouble() or nextLong() call is made after each run and added to a sink to keep the final state observable.\n");
+        out.append("- The output reports only the average time per stream operation.\n\n");
+
+        out.append("Generators:\n");
+        out.append("- MWC64k2a2\n");
+        out.append("- MWC64k3a2\n");
+        out.append("- MRG32k3a\n");
+        out.append("- LFSR258\n");
+        out.append("- Xoroshiro128PlusPlus\n");
+        out.append("- Xoshiro256PlusPlus\n\n");
+
+        out.append("============================================================\n");
+        out.append("Stream-level operation speed\n");
+        out.append("============================================================\n");
+
+        benchmarkMWC64k2a2StreamCreation(out);
+        benchmarkMWC64k3a2StreamCreation(out);
+        benchmarkMRG32k3aStreamCreation(out);
+        benchmarkLFSR258StreamCreation(out);
+
+        benchmarkJavaLeap(out, JAVA_XOROSHIRO128_PP);
+        benchmarkJavaLeap(out, JAVA_XOSHIRO256_PP);
+
+        out.append("\nFinal sink, used to prevent dead-code elimination:\n");
+        out.append("sink = ").append(sink).append("\n");
+
+        System.out.println(out);
+
+        if (WRITE_FILE) {
+            FileWriter writer = new FileWriter(outputFile);
+            writer.write(out.toString());
+            writer.close();
+        }
+    }
+
+    private static String formatNs(double ns) {
+        return String.format(Locale.US, "%.3f", ns);
+    }
+
+    private static String formatJumpDistance(double distance) {
+        if (distance > 0.0) {
+            int exponent = (int) Math.round(Math.log(distance) / Math.log(2.0));
+            double power = Math.pow(2.0, exponent);
+
+            if (Double.compare(power, distance) == 0)
+                return "2**" + exponent;
+        }
+
+        return String.format(Locale.US, "%.0f", distance);
+    }
+
+    private static void benchmarkMWC64k2a2StreamCreation(StringBuilder out) {
+        out.append("\nMWC64k2a2 new stream creation\n");
+        out.append("Stream distance: 2**113\n");
+
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            MWC64k2a2 gen = null;
+            for (int i = 0; i < M; i++)
+                gen = new MWC64k2a2();
+            sink += gen.nextDouble();
+        }
+
+        double totalTime = 0.0;
+
+        for (int run = 0; run < TIMED_RUNS; run++) {
+            MWC64k2a2 gen = null;
+
+            long start = System.nanoTime();
+
+            for (int i = 0; i < M; i++)
+                gen = new MWC64k2a2();
+
+            long end = System.nanoTime();
+
+            totalTime += (end - start) * 1.0e-9;
+            sink += gen.nextDouble();
+        }
+
+        printResult(out, totalTime);
+    }
+
+    private static void benchmarkMWC64k3a2StreamCreation(StringBuilder out) {
+        out.append("\nMWC64k3a2 new stream creation\n");
+        out.append("Stream distance: 2**169\n");
+
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            MWC64k3a2 gen = null;
+            for (int i = 0; i < M; i++)
+                gen = new MWC64k3a2();
+            sink += gen.nextDouble();
+        }
+
+        double totalTime = 0.0;
+
+        for (int run = 0; run < TIMED_RUNS; run++) {
+            MWC64k3a2 gen = null;
+
+            long start = System.nanoTime();
+
+            for (int i = 0; i < M; i++)
+                gen = new MWC64k3a2();
+
+            long end = System.nanoTime();
+
+            totalTime += (end - start) * 1.0e-9;
+            sink += gen.nextDouble();
+        }
+
+        printResult(out, totalTime);
+    }
+
+    private static void benchmarkMRG32k3aStreamCreation(StringBuilder out) {
+        out.append("\nMRG32k3a new stream creation\n");
+        out.append("Stream distance: 2**127\n");
+
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            MRG32k3a gen = null;
+            for (int i = 0; i < M; i++)
+                gen = new MRG32k3a();
+            sink += gen.nextDouble();
+        }
+
+        double totalTime = 0.0;
+
+        for (int run = 0; run < TIMED_RUNS; run++) {
+            MRG32k3a gen = null;
+
+            long start = System.nanoTime();
+
+            for (int i = 0; i < M; i++)
+                gen = new MRG32k3a();
+
+            long end = System.nanoTime();
+
+            totalTime += (end - start) * 1.0e-9;
+            sink += gen.nextDouble();
+        }
+
+        printResult(out, totalTime);
+    }
+
+    private static void benchmarkLFSR258StreamCreation(StringBuilder out) {
+        out.append("\nLFSR258 new stream creation\n");
+        out.append("Stream distance: 2**200\n");
+
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            LFSR258 gen = null;
+            for (int i = 0; i < M; i++)
+                gen = new LFSR258();
+            sink += gen.nextDouble();
+        }
+
+        double totalTime = 0.0;
+
+        for (int run = 0; run < TIMED_RUNS; run++) {
+            LFSR258 gen = null;
+
+            long start = System.nanoTime();
+
+            for (int i = 0; i < M; i++)
+                gen = new LFSR258();
+
+            long end = System.nanoTime();
+
+            totalTime += (end - start) * 1.0e-9;
+            sink += gen.nextDouble();
+        }
+
+        printResult(out, totalTime);
+    }
+
+    private static void benchmarkJavaLeap(StringBuilder out, String algorithm) {
+        out.append("\n").append(algorithm).append(" leap()\n");
+
+        RandomGenerator gen0 = RandomGeneratorFactory.of(algorithm).create(JAVA_SEED);
+
+        if (!(gen0 instanceof RandomGenerator.LeapableGenerator)) {
+            out.append("Skipped: this generator does not implement LeapableGenerator.\n");
+            return;
+        }
+
+        RandomGenerator.LeapableGenerator gen =
+                (RandomGenerator.LeapableGenerator) gen0;
+
+        out.append("Leap distance reported by Java: ")
+           .append(formatJumpDistance(gen.leapDistance()))
+           .append("\n");
+
+        for (int run = 0; run < WARMUP_RUNS; run++) {
+            for (int i = 0; i < M; i++)
+                gen.leap();
+            sink += gen.nextLong();
+        }
+
+        double totalTime = 0.0;
+
+        for (int run = 0; run < TIMED_RUNS; run++) {
+            long start = System.nanoTime();
+
+            for (int i = 0; i < M; i++)
+                gen.leap();
+
+            long end = System.nanoTime();
+
+            totalTime += (end - start) * 1.0e-9;
+            sink += gen.nextLong();
+        }
+
+        printResult(out, totalTime);
+    }
+
+    private static void printResult(StringBuilder out, double totalTime) {
+        double averageRunSeconds = totalTime / TIMED_RUNS;
+        double nsPerOperation = averageRunSeconds * 1.0e9 / M;
+
+        out.append("Warmup: ").append(WARMUP_RUNS).append(" run of ")
+           .append(M_LABEL).append(" stream operations, excluded.\n");
+        out.append("Average time per stream operation over ").append(TIMED_RUNS)
+           .append(" timed runs, each with ").append(M_LABEL).append(" operations: ")
+           .append(formatNs(nsPerOperation)).append(" ns\n");
+    }
+}

--- a/src/main/docs/examples/rqmcexperiments/GenzGaussian.java
+++ b/src/main/docs/examples/rqmcexperiments/GenzGaussian.java
@@ -103,9 +103,5 @@ public class GenzGaussian implements MonteCarloModelDouble {
    public String getTag() {
       return "GenzGaussian";
    }
-   
-   /////////for test
-   public double getExactMean() {
-	   return exactMean;
-	}
+
 }

--- a/src/main/docs/examples/rqmcexperiments/GenzOscillatory.java
+++ b/src/main/docs/examples/rqmcexperiments/GenzOscillatory.java
@@ -34,8 +34,8 @@ public class GenzOscillatory implements MonteCarloModelDouble {
          throw new IllegalArgumentException("s must be positive");
       if (c == null || c.length != s)
          throw new IllegalArgumentException("c must have length s");
-      if (!(w1 > 0.0 && w1 < 1.0))
-         throw new IllegalArgumentException("w1 must be in (0, 1)");
+      if (!(w1 >= 0.0 && w1 < 1.0))
+         throw new IllegalArgumentException("w1 must be in [0, 1)");
 
       for (int j = 0; j < s; j++) {
          if (!(c[j] > 0.0))

--- a/src/main/docs/examples/rqmcexperiments/GenzProductPeak.java
+++ b/src/main/docs/examples/rqmcexperiments/GenzProductPeak.java
@@ -101,9 +101,4 @@ public class GenzProductPeak implements MonteCarloModelDouble {
    public String getTag() {
       return "GenzProductPeak";
    }
-   
-   /////////for test
-   public double getExactMean() {
-	   return exactMean;
-	}
 }

--- a/src/main/java/umontreal/ssj/rng/MWC64k2a2.java
+++ b/src/main/java/umontreal/ssj/rng/MWC64k2a2.java
@@ -197,8 +197,6 @@ public class MWC64k2a2 extends RandomStreamBase {
    /**
     * Returns the next uniform in (0,1).
     *
-    * This follows the C style:
-    *
     * <pre>
     * block53 = nextNumber() >>> 11
     * if block53 == 0, try again
@@ -207,28 +205,47 @@ public class MWC64k2a2 extends RandomStreamBase {
     *
     * @return next uniform in (0,1)
     */
-   protected double nextValue() {
-      long block53;                       // Will contain the top 53 bits.
-
-      do {
-         block53 = nextNumber() >>> 11;   // Keep top 53 bits of 64-bit output.
-      } while (block53 == 0L);            // Reject 0 to avoid returning 0.0.
-
-      return block53 * NORM53;            // Convert to double.
-   }
+//   protected double nextValue() {
+//      long block53;                       // Will contain the top 53 bits.
+//
+//      do {
+//         block53 = nextNumber() >>> 11;   // Keep top 53 bits of 64-bit output.
+//      } while (block53 == 0L);            // Reject 0 to avoid returning 0.0.
+//
+//      return block53 * NORM53;            // Convert to double.
+//   }
    
    /**
-    * Returns a random long in [i, j].
+    * Returns the next uniform in [0, 1).
     *
-    * @param i lower bound
-    * @param j upper bound
-    * @return random long in [i, j]
+    * <p>
+    * This method keeps the top 53 bits of the 64-bit output and multiplies
+    * by 2^(-53). It may return 0.0, but it never returns 1.0.
+    * The RandomStream interface provides nextDoubleNonzero() when a nonzero
+    * uniform is needed.
+    * </p>
+    *
+    * <pre>
+    * return (nextNumber() >>> 11) * 2^(-53)
+    * </pre>
+    *
+    * @return the next uniform in [0, 1)
     */
-   
-   // This method implements the "unbiased bounded integer generation" algorithm used by java.util.Random.nextint, which is based on rejection sampling to avoid modulo bias.
-   //It handles the case where the range size may exceed 2^63 by using a different approach (n <= 0 due to overflow). 
-   //also includes optimizations for power-of-two range sizes.
-   // uses 63 bits entropy in the case of n >0
+   protected double nextValue() {
+      return (nextNumber() >>> 11) * NORM53;
+   }
+ 
+   /**
+    * Returns a random long in the inclusive range {@code [i, j]}.
+    *
+    * Uses 63 random bits and rejection sampling when the range size fits in a
+    * positive long. For larger ranges, it samples full 64-bit values until one
+    * falls inside the interval.
+    *
+    * @param i lower bound, inclusive
+    * @param j upper bound, inclusive
+    * @return a random long in {@code [i, j]}
+    */
    public long nextLong(long i, long j) {
       if (i > j)
          throw new IllegalArgumentException(i + " is larger than " + j + ".");
@@ -273,7 +290,15 @@ public class MWC64k2a2 extends RandomStreamBase {
 	      return i + (res / q);
 	   }
    
-   // return a block of b bits (int):
+   /**
+    * Returns the top b bits of the next 64-bit output.
+    *
+    * The selected bits are shifted to the right, so the result is stored in the
+    * least significant b bits of the returned long.
+    *
+    * @param b number of bits to return, between 1 and 64
+    * @return the top b bits of the next 64-bit output
+    */
    public long nextBitsLong(int b) {
 	    return nextNumber() >>> (64 - b);
 	}

--- a/src/main/java/umontreal/ssj/rng/MWC64k3a2.java
+++ b/src/main/java/umontreal/ssj/rng/MWC64k3a2.java
@@ -211,45 +211,36 @@ public class MWC64k3a2 extends RandomStreamBase {
    }
 
    /**
-    * Returns the next uniform in (0,1).
+    * Returns the next uniform in [0, 1).
     *
-    * This follows the C style:
+    * <p>
+    * This method keeps the top 53 bits of the 64-bit output and multiplies
+    * by 2^(-53). It may return 0.0, but it never returns 1.0.
+    * The RandomStream interface provides nextDoubleNonzero() when a nonzero
+    * uniform is needed.
+    * </p>
     *
     * <pre>
-    * block53 = nextNumber() >>> 11
-    * if block53 == 0, try again
-    * return block53 * 2^(-53)
+    * return (nextNumber() >>> 11) * 2^(-53)
     * </pre>
     *
-    * @return next uniform in (0,1)
+    * @return the next uniform in [0, 1)
     */
    protected double nextValue() {
-      long block53;                       // Will contain the top 53 bits.
-
-      do {
-         block53 = nextNumber() >>> 11;   // Keep top 53 bits of 64-bit output.
-      } while (block53 == 0L);            // Reject 0 to avoid returning 0.0.
-
-      return block53 * NORM53;            // Convert to double.
+      return (nextNumber() >>> 11) * NORM53;
    }
    
    /**
-    * Another possibility to avoid returning 0 ?
-    */
-//   protected double nextValue2() {
-//      return ((nextNumber() >>> 11) + 0.5) * NORM53;
-//   }
-   
-   /**
-    * Returns a random long in [i, j].
+    * Returns a random long in the inclusive range {@code [i, j]}.
     *
-    * @param i lower bound
-    * @param j upper bound
-    * @return random long in [i, j]
+    * Uses 63 random bits and rejection sampling when the range size fits in a
+    * positive long. For larger ranges, it samples full 64-bit values until one
+    * falls inside the interval.
+    *
+    * @param i lower bound, inclusive
+    * @param j upper bound, inclusive
+    * @return a random long in {@code [i, j]}
     */
-   
-   // This method implements the "unbiased bounded integer generation" algorithm used by java.util.Random.nextint.
-   // uses 63 bits entropy in the case of n >0
    public long nextLong(long i, long j) {
       if (i > j)
          throw new IllegalArgumentException(i + " is larger than " + j + ".");
@@ -293,8 +284,16 @@ public class MWC64k3a2 extends RandomStreamBase {
 
          return i + (res / q);
       }
-   
-   // return a block of b bits (int)
+  
+   /**
+    * Returns the top b bits of the next 64-bit output.
+    *
+    * The selected bits are shifted to the right, so the result is stored in the
+    * least significant b bits of the returned long.
+    *
+    * @param b number of bits to return, between 1 and 64
+    * @return the top b bits of the next 64-bit output
+    */
    public long nextBitsLong(int b) {
       return nextNumber() >>> (64 - b);
    }


### PR DESCRIPTION
Updates MWC64k2a2 and MWC64k3a2 nextDouble (0 allowed, interface handles non zero case).
Adds RNG experiment classes under rngexperiments:
-RngCommonOutputSpeed:  Speed comparaison with other ssj and java rng (public methods)
-RngJumpSpeed:  SubSteam fixed jumps speed comparaison
-RngStreamJumpSpeed: Stream fixed jumps speed comparaison
