### PR TITLE
Develop: Otman  : Update MWC64 stream and substream jumps

### DIFF
--- a/src/main/docs/examples/rngexperiments/CompareMWCvsCpp.java
+++ b/src/main/docs/examples/rngexperiments/CompareMWCvsCpp.java
@@ -2,8 +2,7 @@ package rngexperiments;
 
 import java.io.FileWriter;
 import java.math.BigInteger;
-import java.io.PrintWriter;
-import java.math.BigInteger;
+
 import java.io.IOException;
 import umontreal.ssj.rng.MWC64k2a2;
 import umontreal.ssj.rng.MWC64k3a2;
@@ -26,7 +25,7 @@ public class CompareMWCvsCpp {
     *   n = 1,000,000 jumps for timing
     *   
     */
-   private static final long N_SPEED = 10_000__000L;
+   private static final long N_SPEED = 10_000__000_000L;
    private static final long JUMP_SIZE = 5000L;
    private static final long N_JUMPS = 1000_000L;
 

--- a/src/main/docs/examples/rngexperiments/CompareMWCvsCpp.java
+++ b/src/main/docs/examples/rngexperiments/CompareMWCvsCpp.java
@@ -2,7 +2,6 @@ package rngexperiments;
 
 import java.io.FileWriter;
 import java.math.BigInteger;
-
 import java.io.IOException;
 import umontreal.ssj.rng.MWC64k2a2;
 import umontreal.ssj.rng.MWC64k3a2;

--- a/src/main/docs/examples/rngexperiments/CompareMWCvsCpp.java
+++ b/src/main/docs/examples/rngexperiments/CompareMWCvsCpp.java
@@ -1,7 +1,9 @@
 package rngexperiments;
 
 import java.io.FileWriter;
+import java.math.BigInteger;
 import java.io.PrintWriter;
+import java.math.BigInteger;
 import java.io.IOException;
 import umontreal.ssj.rng.MWC64k2a2;
 import umontreal.ssj.rng.MWC64k3a2;
@@ -24,7 +26,7 @@ public class CompareMWCvsCpp {
     *   n = 1,000,000 jumps for timing
     *   
     */
-   private static final long N_SPEED = 10_000_000_000L;
+   private static final long N_SPEED = 10_000__000L;
    private static final long JUMP_SIZE = 5000L;
    private static final long N_JUMPS = 1000_000L;
 
@@ -171,7 +173,7 @@ public class CompareMWCvsCpp {
       long start = System.nanoTime();
 
       for (int i = 1; i <= 4; i++) {
-         rng.advanceStateByJump(JUMP_SIZE);
+         rng.advanceStateByJump(BigInteger.valueOf(JUMP_SIZE));
          out.append("after jump " + i + " = " + state(rng.getState()) + "\n");
       }
 
@@ -189,7 +191,7 @@ public class CompareMWCvsCpp {
 
       start = System.nanoTime();
 
-      rng.advanceStateByJump(4L * JUMP_SIZE);
+      rng.advanceStateByJump(BigInteger.valueOf(JUMP_SIZE).multiply(BigInteger.valueOf(4L)));
 
       end = System.nanoTime();
 
@@ -210,7 +212,7 @@ public class CompareMWCvsCpp {
       start = System.nanoTime();
 
       for (long i = 0; i < N_JUMPS; i++) {
-    	  rng.advanceStateByJump(JUMP_SIZE);
+    	  rng.advanceStateByJump(BigInteger.valueOf(JUMP_SIZE));
       }
 
       end = System.nanoTime();

--- a/src/main/docs/examples/rngexperiments/RngFixedJumpSpeed.java
+++ b/src/main/docs/examples/rngexperiments/RngFixedJumpSpeed.java
@@ -6,7 +6,6 @@ import java.io.IOException;
 import umontreal.ssj.rng.MRG32k3a;
 import umontreal.ssj.rng.MWC64k2a2;
 import umontreal.ssj.rng.MWC64k3a2;
-import umontreal.ssj.rng.MWC64k3a2;
 import umontreal.ssj.rng.LFSR258;
 import umontreal.ssj.rng.RandomStream;
 

--- a/src/main/docs/examples/rngexperiments/RngFixedJumpSpeed.java
+++ b/src/main/docs/examples/rngexperiments/RngFixedJumpSpeed.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import umontreal.ssj.rng.MRG32k3a;
 import umontreal.ssj.rng.MWC64k2a2;
 import umontreal.ssj.rng.MWC64k3a2;
+import umontreal.ssj.rng.MWC64k3a2;
 import umontreal.ssj.rng.LFSR258;
 import umontreal.ssj.rng.RandomStream;
 
@@ -32,7 +33,7 @@ public class RngFixedJumpSpeed {
     static final int M = 1_000_000;
 
     /** Number of runs. Run 1 is warm-up and is not included in the average. */
-    static final int N = 5;
+    static final int N = 6;
 
     /**
      * Sink variable used to prevent the JVM from removing object creation

--- a/src/main/docs/examples/rngexperiments/TestMWC64k3a2Jump.java
+++ b/src/main/docs/examples/rngexperiments/TestMWC64k3a2Jump.java
@@ -2,7 +2,6 @@ package rngexperiments;
 
 import java.math.BigInteger;
 import java.util.Arrays;
-
 import umontreal.ssj.rng.MWC64k3a2;
 
 /**

--- a/src/main/docs/examples/rngexperiments/TestMWC64k3a2Jump.java
+++ b/src/main/docs/examples/rngexperiments/TestMWC64k3a2Jump.java
@@ -72,8 +72,8 @@ public class TestMWC64k3a2Jump {
     */
    public static void main(String[] args) {
       testJumpAgainstGeneration();
-//      testSubstreamJump();// needs big integer as params of advanceStateByJump
-//      testStreamJump(); // needs big integer as params of advanceStateByJump
+      testSubstreamJump();// needs big integer as params of advanceStateByJump
+      testStreamJump(); // needs big integer as params of advanceStateByJump
 
       System.out.println();
       System.out.println("======================================");
@@ -110,7 +110,7 @@ public class TestMWC64k3a2Jump {
                byGeneration.nextRaw();
 
             // Jump path: advance the state directly by n steps.
-            byJump.advanceStateByJump(n); // must be updated if advanceStateByJump takes BigInteger
+            byJump.advanceStateByJump(BigInteger.valueOf(n)); // must be updated if advanceStateByJump takes BigInteger
 
             long[] expected = byGeneration.getState();
             long[] actual = byJump.getState();
@@ -145,7 +145,7 @@ public class TestMWC64k3a2Jump {
     *
     * This checks that the hardcoded/precomputed substream jump constants are correct.
     */
-  /* private static void testSubstreamJump() {
+   private static void testSubstreamJump() {
       System.out.println();
       System.out.println("======================================");
       System.out.println("TEST 2: resetNextSubstream() vs jump(2^" + SUBSTREAM_ADVANCE_EXPONENT + ")");
@@ -193,13 +193,13 @@ public class TestMWC64k3a2Jump {
          );
       }
    }
-*/
+
    /**
     * Tests that stream creation advances the package seed by 2^169 each time.
     *
     * This checks that the fixed stream jump used in the constructor is correct.
     */
-   /*private static void testStreamJump() {
+   private static void testStreamJump() {
       System.out.println();
       System.out.println("======================================");
       System.out.println("TEST 3: stream creation vs jump(2^" + STREAM_ADVANCE_EXPONENT + ")");
@@ -256,7 +256,7 @@ public class TestMWC64k3a2Jump {
                Arrays.equals(expected3.getState(), stream3State)
          );
       }
-   }*/
+   }
 
    /**
     * Prints one comparison result and updates the GOOD/BAD counters.

--- a/src/main/java/umontreal/ssj/rng/MWC64k2a2.java
+++ b/src/main/java/umontreal/ssj/rng/MWC64k2a2.java
@@ -29,7 +29,7 @@ import java.math.BigInteger;
  * </pre>
  */
 public class MWC64k2a2 extends RandomStreamBase {
-	
+   
    private static final long serialVersionUID = 20260518L;
    
    // State components x_{n-1}, x_{n-2} and c_{n-1} interpreted as unsigned 64-bit. 
@@ -44,19 +44,23 @@ public class MWC64k2a2 extends RandomStreamBase {
    private static final double NORM53 = 0x1.0p-53;
    // Stream spacing: 2^113 generated values. 
    private static final int STREAM_ADVANCE_EXPONENT =  113;
-   // Substream spacing: 2^62	 generated values. 
+   // Substream spacing: 2^62   generated values. 
    private static final int SUBSTREAM_ADVANCE_EXPONENT = 62;
 
    // Seed used for the next created stream: {x_{n-2}, x_{n-1}, carry}. 
    private static long[] nextSeed = {12345L, 12345L, 12345L}; 
+   // LCG state corresponding to nextSeed.
+   private static BigInteger nextSeedY;
    //Initial state of this stream. 
    private long[] Ig;
+   // LCG state corresponding to the beginning of this stream.
+   private BigInteger IgY;
    // Beginning state of the current substream of stream. 
    private long[] Bg;
-  
-   
-    // Precomputed BigInteger constants for the MWC-to-LCG jump transformation.
-    
+   // LCG state corresponding to the beginning of the current substream.
+   private BigInteger BgY;
+ 
+    // Precomputed BigInteger constants for the MWC-to-LCG jump transformation.    
    private static final BigInteger BI_B = BigInteger.ONE.shiftLeft(64); // b = 2^64
    private static final BigInteger BI_A1 = BigInteger.valueOf(A1);
    private static final BigInteger BI_A2 = BigInteger.valueOf(A2); 
@@ -68,32 +72,23 @@ public class MWC64k2a2 extends RandomStreamBase {
 
    private static final BigInteger STREAM_JUMP_MULTIPLIER = BI_B_INV.modPow(BigInteger.ONE.shiftLeft(STREAM_ADVANCE_EXPONENT), BI_M); // J = (b^(-1))^(2^STREAM_JUMP_EXPONENT) mod m
    private static final BigInteger SUBSTREAM_JUMP_MULTIPLIER = BI_B_INV.modPow(BigInteger.ONE.shiftLeft(SUBSTREAM_ADVANCE_EXPONENT), BI_M); // J = (b^(-1))^(2^SUBSTREAM_JUMP_EXPONENT) mod m
-   private static final BigInteger STREAM_K_X2 = STREAM_JUMP_MULTIPLIER.multiply(BI_MAP_X2).mod(BI_M); // K_x2 = J*(1 - a1*b) mod m
-   private static final BigInteger STREAM_K_X1 = STREAM_JUMP_MULTIPLIER.multiply(BI_B).mod(BI_M); // K_x1 = J*b mod m
-   private static final BigInteger STREAM_K_C  = STREAM_JUMP_MULTIPLIER.multiply(BI_B2).mod(BI_M); // K_c = J*b^2 mod m
-   private static final BigInteger SUBSTREAM_K_X2 = SUBSTREAM_JUMP_MULTIPLIER.multiply(BI_MAP_X2).mod(BI_M); // K_x2 = J*(1 - a1*b) mod m
-   private static final BigInteger SUBSTREAM_K_X1 = SUBSTREAM_JUMP_MULTIPLIER.multiply(BI_B).mod(BI_M); // K_x1 = J*b mod m
-   private static final BigInteger SUBSTREAM_K_C  = SUBSTREAM_JUMP_MULTIPLIER.multiply(BI_B2).mod(BI_M);// K_c = J*b^2 mod m
-   
-//   /*For A1 = 193154555888013165L; A2 = 1966812196490295L; STREAM_ADVANCE_EXPONENT = 113; SUBSTREAM_ADVANCE_EXPONENT = 62
-//    * These values are precalculated and hardcoded here 
-//    * */
-//   private static final BigInteger STREAM_K_X2 = new BigInteger("550287765979488443922754971547870548747622917622202515");//Only for the given A1, A2 and the given jumpsizes
-//   private static final BigInteger STREAM_K_X1 = new BigInteger("590664228179752031471436901652469203082748750179775222");//Only for the given A1, A2 and the given jumpsizes
-//   private static final BigInteger STREAM_K_C  = new BigInteger("521510005202858839425516464682983339842500770120428048");//Only for the given A1, A2 and the given jumpsizes
-//   private static final BigInteger  SUBSTREAM_K_X2 = new BigInteger("253956167587244238733053471042992883266608765200613794");// Only for the given A1, A2 and the given jumpsizes
-//   private static final BigInteger SUBSTREAM_K_X1 = new BigInteger("334142836076716064087784195971406862825997835485950288");//Only for the given A1, A2 and the given jumpsizes
-//   private static final BigInteger SUBSTREAM_K_C  = new BigInteger("475660625350411904999072789094749200216738394742542956");//Only for the given A1, A2 and the given jumpsizes
+
+   // Initialize the LCG state corresponding to the default package seed.
+   static {
+      nextSeedY = stateToLCG(nextSeed);
+   }
  
    /**
     * Constructs a new stream.
     */
    public MWC64k2a2() {
-      Ig = nextSeed.clone();              // Save the start state of this stream.
+      Ig = nextSeed.clone();              // Save the start MWC state of this stream.
+      IgY = nextSeedY;                    // Save the matching LCG state.
       Bg = new long[3];                   // Allocate the substream state.
 
       resetStartStream();                 // Set Bg and current state from Ig.
-      advanceStateFixedJump(nextSeed, STREAM_K_X2,STREAM_K_X1, STREAM_K_C); // using precomputed constant for Stream advance
+
+      nextSeedY = advanceLCGState(nextSeedY, STREAM_JUMP_MULTIPLIER, nextSeed); // Prepare the next stream seed.
    }        
 
    /**
@@ -114,6 +109,7 @@ public class MWC64k2a2 extends RandomStreamBase {
    public static void setPackageSeed(long[] seed) {
       checkSeed(seed);                    // Validate seed.
       nextSeed = seed.clone();            // Copy seed to avoid external mutation.
+      nextSeedY = stateToLCG(nextSeed);   // Store the matching LCG state.
    }
 
    /**
@@ -124,6 +120,7 @@ public class MWC64k2a2 extends RandomStreamBase {
    public void setSeed(long[] seed) {
       checkSeed(seed);                    // Validate seed.
       Ig = seed.clone();                  // Replace initial stream state.
+      IgY = stateToLCG(Ig);               // Store the matching LCG state.
       resetStartStream();                 // Restart stream from new seed.
    }
 
@@ -143,6 +140,7 @@ public class MWC64k2a2 extends RandomStreamBase {
       Bg[0] = Ig[0];                      // Substream start = stream start.
       Bg[1] = Ig[1];
       Bg[2] = Ig[2];
+      BgY = IgY;                          // Substream LCG state = stream LCG state.
 
       resetStartSubstream();              // Current state = substream start.
    }
@@ -160,7 +158,7 @@ public class MWC64k2a2 extends RandomStreamBase {
     * Moves this stream to the beginning of the next substream.
     */
    public void resetNextSubstream() {
-	  advanceStateFixedJump(Bg, SUBSTREAM_K_X2, SUBSTREAM_K_X1, SUBSTREAM_K_C);
+      BgY = advanceLCGState(BgY, SUBSTREAM_JUMP_MULTIPLIER, Bg); // Advance the substream LCG state.
       resetStartSubstream();   
    }
 
@@ -277,18 +275,18 @@ public class MWC64k2a2 extends RandomStreamBase {
    
    // LRSR version: range only up to 2^62  : should add guard to handle case where range is bigger
    public long nextLongssj(long i, long j) { 
-	      if (i > j)
-	         throw new IllegalArgumentException(i + " is larger than " + j + ".");
-	      long d = j - i + 1;
-	      long q = 0x4000000000000000L / d;  // 0x4000000000000000L = 2^{62} in hexadecimal.
-	      long r = 0x4000000000000000L % d;
-	      long res;
-	      do {
-	         res = nextNumber() >>> 2;   // Integer smaller than 2^{62}.
-	      } while (res >= 0x4000000000000000L - r);
+         if (i > j)
+            throw new IllegalArgumentException(i + " is larger than " + j + ".");
+         long d = j - i + 1;
+         long q = 0x4000000000000000L / d;  // 0x4000000000000000L = 2^{62} in hexadecimal.
+         long r = 0x4000000000000000L % d;
+         long res;
+         do {
+            res = nextNumber() >>> 2;   // Integer smaller than 2^{62}.
+         } while (res >= 0x4000000000000000L - r);
 
-	      return i + (res / q);
-	   }
+         return i + (res / q);
+      }
    
    /**
     * Returns the top b bits of the next 64-bit output.
@@ -300,8 +298,8 @@ public class MWC64k2a2 extends RandomStreamBase {
     * @return the top b bits of the next 64-bit output
     */
    public long nextBitsLong(int b) {
-	    return nextNumber() >>> (64 - b);
-	}
+      return nextNumber() >>> (64 - b);
+   }
 
    /**
     * Returns a random int in [i, j].
@@ -379,6 +377,8 @@ public class MWC64k2a2 extends RandomStreamBase {
 
       copy.Ig = Ig.clone();               // Copy stream-start state.
       copy.Bg = Bg.clone();               // Copy substream-start state.
+      copy.IgY = IgY;                     // BigInteger is immutable; assignment is safe.
+      copy.BgY = BgY;                     // Keep cloned substream LCG state consistent.
 
       return copy;
    }
@@ -410,56 +410,19 @@ public class MWC64k2a2 extends RandomStreamBase {
    }
 
    /**
-    * Advances by a fixed jump size predefined by precomputed constants
-    *
-    * The state is {x_{n-2}, x_{n-1}, carry}.
-    *
-    * @param state state to advance
-    * @param K_X2 x2 multiplier 
-    * @param K_X1  x1  multiplier
-    * @param K_C   carry multiplier
-    */
-   
-   private static void advanceStateFixedJump(long[] state,BigInteger K_X2, BigInteger K_X1, BigInteger K_C) {
-	   BigInteger stateX2 = toUnsignedBigInt(state[0]);
-	   BigInteger stateX1 = toUnsignedBigInt(state[1]);
-	   BigInteger stateCarry = BigInteger.valueOf(state[2]);
-
-	   BigInteger sigma =
-	         K_X2.multiply(stateX2)
-	       .add(K_X1.multiply(stateX1))
-	       .add(K_C.multiply(stateCarry))
-	       .mod(BI_M);
-
-	   long newX2 = sigma.longValue();
-	   sigma = sigma.shiftRight(64);
-
-	   sigma = sigma.add(BI_A1.multiply(toUnsignedBigInt(newX2)));
-
-	   long newX1 = sigma.longValue();
-	   long newCarry = sigma.shiftRight(64).longValue();
-
-	   state[0] = newX2;
-	   state[1] = newX1;
-	   state[2] = newCarry;
-	}
-   
-   /**
     * Advances the current stream state by n steps.
     *
-    * This method is for a general jump size n. It does not use
-    * advanceStateFixedJump and does not compute fixed-jump coefficients.
-    *
-    * It maps the current MWC state to the equivalent LCG state, applies
+    * This method is for a general jump size n. It maps the current MWC
+    * state to the equivalent LCG state, applies
     * the LCG jump, then converts the result back to the MWC state.
     *
     * @param n number of steps to jump
     */
-   public void advanceStateByJump(long n) {
-      if (n < 0)
+   public void advanceStateByJump(BigInteger n) {
+      if (n.signum() < 0)
          throw new IllegalArgumentException("Jump step n cannot be negative.");
 
-      if (n == 0)
+      if (n.signum() == 0)
          return;
 
       BigInteger stateX2 = toUnsignedBigInt(x2);
@@ -477,7 +440,7 @@ public class MWC64k2a2 extends RandomStreamBase {
 
       // Apply the LCG jump: y_new = (b^(-1))^n * y mod m.
       BigInteger sigma =
-            BI_B_INV.modPow(BigInteger.valueOf(n), BI_M)
+            BI_B_INV.modPow(n, BI_M)
           .multiply(y)
           .mod(BI_M);
 
@@ -493,6 +456,59 @@ public class MWC64k2a2 extends RandomStreamBase {
       x2 = newX2;
       x1 = newX1;
       carry = newCarry;
+   }
+
+   /**
+    * Advances a stored LCG state by a fixed stream or substream jump.
+    *
+    * @param y stored LCG state to advance
+    * @param jumpMultiplier precomputed fixed jump multiplier
+    * @param state MWC state to receive the recovered value
+    * @return advanced LCG state
+    */
+   private static BigInteger advanceLCGState(BigInteger y, BigInteger jumpMultiplier, long[] state) {
+      BigInteger newY = jumpMultiplier.multiply(y).mod(BI_M);
+      stateFromLCG(newY, state);
+      return newY;
+   }
+
+   /**
+    * Maps a MWC state {x_{n-2}, x_{n-1}, carry} to its LCG state.
+    *
+    * @param state MWC state
+    * @return corresponding LCG state
+    */
+   private static BigInteger stateToLCG(long[] state) {
+      BigInteger stateX2 = toUnsignedBigInt(state[0]);
+      BigInteger stateX1 = toUnsignedBigInt(state[1]);
+      BigInteger stateCarry = BigInteger.valueOf(state[2]);
+
+      return BI_MAP_X2.multiply(stateX2)
+            .add(BI_B.multiply(stateX1))
+            .add(BI_B2.multiply(stateCarry))
+            .mod(BI_M);
+   }
+
+   /**
+    * Recovers a MWC state {x_{n-2}, x_{n-1}, carry} from an LCG state.
+    *
+    * @param y LCG state
+    * @param state MWC state to update
+    */
+   private static void stateFromLCG(BigInteger y, long[] state) {
+      BigInteger sigma = y;
+
+      long newX2 = sigma.longValue();
+      sigma = sigma.shiftRight(64);
+
+      sigma = sigma.add(BI_A1.multiply(toUnsignedBigInt(newX2)));
+
+      long newX1 = sigma.longValue();
+      long newCarry = sigma.shiftRight(64).longValue();
+
+      state[0] = newX2;
+      state[1] = newX1;
+      state[2] = newCarry;
    }
    
    //for test

--- a/src/main/java/umontreal/ssj/rng/MWC64k3a2.java
+++ b/src/main/java/umontreal/ssj/rng/MWC64k3a2.java
@@ -58,12 +58,16 @@ public class MWC64k3a2 extends RandomStreamBase {
    private static long[] nextSeed = {1L, 3L, 4L, 5L};
    // Initial state of this stream. 
    private long[] Ig;
-   //Beginning state of the current substream of stream. 
+   // Beginning state of the current substream of stream. 
    private long[] Bg;
-  
+   // LCG state corresponding to nextSeed.
+   private static BigInteger nextSeedY;
+   // LCG state at the beginning of this stream.
+   private BigInteger IgY;
+   // LCG state at the beginning of the current substream.
+   private BigInteger BgY;
    
-   // Precomputed BigInteger constants for the MWC-to-LCG jump transformation.
-    
+   // Precomputed BigInteger constants for the MWC-to-LCG jump transformation.	  
    private static final BigInteger BI_B = BigInteger.ONE.shiftLeft(64); // b = 2^64
    private static final BigInteger BI_B2 = BigInteger.ONE.shiftLeft(128); // b^2
    private static final BigInteger BI_B3 = BigInteger.ONE.shiftLeft(192); // b^3
@@ -75,38 +79,21 @@ public class MWC64k3a2 extends RandomStreamBase {
    
    private static final BigInteger STREAM_JUMP_MULTIPLIER = BI_B_INV.modPow(BigInteger.ONE.shiftLeft(STREAM_ADVANCE_EXPONENT), BI_M);
    private static final BigInteger SUBSTREAM_JUMP_MULTIPLIER = BI_B_INV.modPow(BigInteger.ONE.shiftLeft(SUBSTREAM_ADVANCE_EXPONENT), BI_M);
-   private static final BigInteger STREAM_K_X3 = STREAM_JUMP_MULTIPLIER.multiply(BI_MAP_X3).mod(BI_M); // K_x3 = J*(1 - a2*b^2) mod m
-   private static final BigInteger STREAM_K_X2 = STREAM_JUMP_MULTIPLIER.multiply(BI_B).mod(BI_M); // K_x2 = J*b mod m
-   private static final BigInteger STREAM_K_X1 = STREAM_JUMP_MULTIPLIER.multiply(BI_B2).mod(BI_M); // K_x1 = J*b^2 mod m
-   private static final BigInteger STREAM_K_C = STREAM_JUMP_MULTIPLIER.multiply(BI_B3).mod(BI_M); // K_c = J*b^3 mod m
-   private static final BigInteger SUBSTREAM_K_X3 = SUBSTREAM_JUMP_MULTIPLIER.multiply(BI_MAP_X3).mod(BI_M); // K_x3 = J*(1 - a2*b^2) mod m
-   private static final BigInteger SUBSTREAM_K_X2 = SUBSTREAM_JUMP_MULTIPLIER.multiply(BI_B).mod(BI_M); // K_x2 = J*b mod m
-   private static final BigInteger SUBSTREAM_K_X1 = SUBSTREAM_JUMP_MULTIPLIER.multiply(BI_B2).mod(BI_M); // K_x1 = J*b^2 mod m
-   private static final BigInteger SUBSTREAM_K_C = SUBSTREAM_JUMP_MULTIPLIER.multiply(BI_B3).mod(BI_M); // K_c = J*b^3 mod m
-    
-//  /*For 	A2 = 184698970548483715L;
-//		     A3 = 6028691832887L;
-//		     STREAM_ADVANCE_EXPONENT = 169;
-//		     SUBSTREAM_ADVANCE_EXPONENT= 118; The values are : 
-//   * */
-//   private static final BigInteger STREAM_K_X3 = new BigInteger("30761207224142103968985508472479115773948763076232986832853996703743926");// Only for the given Ai, and jump sizes
-//   private static final BigInteger STREAM_K_X2 = new BigInteger("2872972596550318317758382057880878886623467367682449388684617761028650");
-//   private static final BigInteger STREAM_K_X1 = new BigInteger("4069686296670218292987053305317065107287547089332977129336044355568643");
-//   private static final BigInteger STREAM_K_C  = new BigInteger("34755671117913769181768749032362575598747313001613768640912748315496354");
-//   private static final BigInteger SUBSTREAM_K_X3 = new BigInteger("20090213403734858454669729088644822937139898902572196936652480155985710");
-//   private static final BigInteger SUBSTREAM_K_X2 = new BigInteger("30641754650566983779571625104122293069399614764417128859406251785748295");
-//   private static final BigInteger SUBSTREAM_K_X1 = new BigInteger("29054523288761736837102924918335104151590420345759813743506375422415858");
-//   private static final BigInteger SUBSTREAM_K_C  = new BigInteger("34358740962475771621509856934142753157316553495393517345486280420486523");
+
+   static {
+      nextSeedY = stateToLCG(nextSeed);
+   }
    
    /**
     * Constructs a new stream.
     */
    public MWC64k3a2() {
       Ig = nextSeed.clone();              // Save the start state of this stream.
+      IgY = nextSeedY;                    // Save the corresponding LCG state.
       Bg = new long[4];                   // Allocate the substream state.
 
       resetStartStream();                 // Set Bg and current state from Ig.
-      advanceStateFixedJump(nextSeed, STREAM_K_X3, STREAM_K_X2, STREAM_K_X1, STREAM_K_C);
+      nextSeedY = advanceLCGState(nextSeedY, STREAM_JUMP_MULTIPLIER, nextSeed);
    }
 
    /**
@@ -127,6 +114,7 @@ public class MWC64k3a2 extends RandomStreamBase {
    public static void setPackageSeed(long[] seed) {
       checkSeed(seed);                    // Validate seed.
       nextSeed = seed.clone();            // Copy seed to avoid external mutation.
+      nextSeedY = stateToLCG(nextSeed);   // Store the corresponding LCG state.
    }
 
    /**
@@ -137,6 +125,7 @@ public class MWC64k3a2 extends RandomStreamBase {
    public void setSeed(long[] seed) {
       checkSeed(seed);                    // Validate seed.
       Ig = seed.clone();                  // Replace initial stream state.
+      IgY = stateToLCG(Ig);               // Store the corresponding LCG state.
       resetStartStream();                 // Restart stream from new seed.
    }
 
@@ -157,6 +146,7 @@ public class MWC64k3a2 extends RandomStreamBase {
       Bg[1] = Ig[1];
       Bg[2] = Ig[2];
       Bg[3] = Ig[3];
+      BgY = IgY;                          // LCG state of the current substream start.
 
       resetStartSubstream();              // Current state = substream start.
    }
@@ -175,9 +165,9 @@ public class MWC64k3a2 extends RandomStreamBase {
     * Moves this stream to the beginning of the next substream.
     */
    public void resetNextSubstream() {
-	   advanceStateFixedJump(Bg, SUBSTREAM_K_X3, SUBSTREAM_K_X2, SUBSTREAM_K_X1, SUBSTREAM_K_C);
-	   resetStartSubstream();
-	}
+      BgY = advanceLCGState(BgY, SUBSTREAM_JUMP_MULTIPLIER, Bg);
+      resetStartSubstream();
+   }
 
    /**
     * Generates one MWC step and returns the old x_{n-1},
@@ -378,6 +368,8 @@ public class MWC64k3a2 extends RandomStreamBase {
 
       copy.Ig = Ig.clone();               // Copy stream-start state.
       copy.Bg = Bg.clone();               // Copy substream-start state.
+      copy.IgY = IgY;                     // BigInteger is immutable.
+      copy.BgY = BgY;                     // BigInteger is immutable.
 
       return copy;
    }
@@ -409,46 +401,63 @@ public class MWC64k3a2 extends RandomStreamBase {
    }
 
    /**
-    *  Advances by a fixed jump size predefined by precomputed constants
+    * Maps a MWC state to the corresponding LCG state.
     *
-    * The state is {x_{n-3}, x_{n-2}, x_{n-1}, carry}.
-    *
-    * @param state state to advance
-    * @param kX3 precomputed x3 multiplier
-    * @param kX2 precomputed x2
-    * @param kX1 precomputed x1
-    * @param kCarry precomputed carry multiplier
+    * @param state state {x_{n-3}, x_{n-2}, x_{n-1}, carry}
+    * @return corresponding LCG state
     */
-   
-   private static void advanceStateFixedJump(long[] state,  BigInteger kX3, BigInteger kX2, BigInteger kX1, BigInteger kCarry) {
-		BigInteger stateX3 = toUnsignedBigInt(state[0]);
-		BigInteger stateX2 = toUnsignedBigInt(state[1]);
-		BigInteger stateX1 = toUnsignedBigInt(state[2]);
-		BigInteger stateCarry = BigInteger.valueOf(state[3]);
-		
-		BigInteger sigma =
-		kX3.multiply(stateX3)
-		.add(kX2.multiply(stateX2))
-		.add(kX1.multiply(stateX1))
-		.add(kCarry.multiply(stateCarry))
-		.mod(BI_M);
-		
-		long newX3 = sigma.longValue();
-		sigma = sigma.shiftRight(64);
-		
-		long newX2 = sigma.longValue();
-		sigma = sigma.shiftRight(64);
-		
-		sigma = sigma.add(BI_A2.multiply(toUnsignedBigInt(newX3))); // y = y + A2*newX3 = newX1 + newCarry*b
-		
-		long newX1 = sigma.longValue();
-		long newCarry = sigma.shiftRight(64).longValue();
-		
-		state[0] = newX3;
-		state[1] = newX2;
-		state[2] = newX1;
-		state[3] = newCarry;
-   }	
+   private static BigInteger stateToLCG(long[] state) {
+      BigInteger stateX3 = toUnsignedBigInt(state[0]);
+      BigInteger stateX2 = toUnsignedBigInt(state[1]);
+      BigInteger stateX1 = toUnsignedBigInt(state[2]);
+      BigInteger stateCarry = BigInteger.valueOf(state[3]);
+
+      return BI_MAP_X3.multiply(stateX3)
+            .add(BI_B.multiply(stateX2))
+            .add(BI_B2.multiply(stateX1))
+            .add(BI_B3.multiply(stateCarry))
+            .mod(BI_M);
+   }
+
+   /**
+    * Recovers a MWC state from the corresponding LCG state.
+    *
+    * @param y corresponding LCG state
+    * @param state state array to update
+    */
+   private static void stateFromLCG(BigInteger y, long[] state) {
+      BigInteger sigma = y;
+
+      long newX3 = sigma.longValue();
+      sigma = sigma.shiftRight(64);
+
+      long newX2 = sigma.longValue();
+      sigma = sigma.shiftRight(64);
+
+      sigma = sigma.add(BI_A2.multiply(toUnsignedBigInt(newX3)));
+
+      long newX1 = sigma.longValue();
+      long newCarry = sigma.shiftRight(64).longValue();
+
+      state[0] = newX3;
+      state[1] = newX2;
+      state[2] = newX1;
+      state[3] = newCarry;
+   }
+
+   /**
+    * Advances a stored LCG state by a fixed multiplier and updates the MWC state.
+    *
+    * @param y current LCG state
+    * @param jumpMultiplier fixed jump multiplier
+    * @param state MWC state to update
+    * @return advanced LCG state
+    */
+   private static BigInteger advanceLCGState(BigInteger y, BigInteger jumpMultiplier, long[] state) {
+      BigInteger newY = jumpMultiplier.multiply(y).mod(BI_M);
+      stateFromLCG(newY, state);
+      return newY;
+   }
    
    /**
     * Advances the current stream state by n steps.
@@ -462,11 +471,11 @@ public class MWC64k3a2 extends RandomStreamBase {
     *
     * @param n number of steps to jump
     */
-   public void advanceStateByJump(long n) {
-      if (n < 0L)
+   public void advanceStateByJump(BigInteger n) {
+      if (n.signum() < 0L)
          throw new IllegalArgumentException("Jump step n cannot be negative.");
 
-      if (n == 0)
+      if (n.signum() == 0)
          return;
 
       BigInteger stateX3 = toUnsignedBigInt(x3);
@@ -485,7 +494,7 @@ public class MWC64k3a2 extends RandomStreamBase {
 
       // Apply the LCG jump: y_new = (b^(-1))^n * y mod m.
       BigInteger sigma =
-            BI_B_INV.modPow(BigInteger.valueOf(n), BI_M)
+            BI_B_INV.modPow(n, BI_M)
           .multiply(y)
           .mod(BI_M);
 


### PR DESCRIPTION
Updates MWC64k2a2 and MWC64k3a2 so fixed stream and substream jumps use stored LCG states.

Also updates advanceStateByJump(n)  to take a BigInteger, which makes it easier to test fixed jumps directly. Related jump tests were updated.