### PR TITLE
Update Genz example models: fix docs and expose exact means

### DIFF
--- a/src/main/docs/examples/rqmcexperiments/GenzContinuous.java
+++ b/src/main/docs/examples/rqmcexperiments/GenzContinuous.java
@@ -27,7 +27,7 @@ public class GenzContinuous implements MonteCarloModelDouble {
     *
     * @param s dimension of the function
     * @param c scale parameters, all strictly positive
-    * @param w location parameters, all in the open interval @f$(0,1)@f$
+    * @param w location parameters, all in the half-open interval @f$[0,1)@f$
     */
    public GenzContinuous(int s, double[] c, double[] w) {
       if (s <= 0)
@@ -109,8 +109,8 @@ public class GenzContinuous implements MonteCarloModelDouble {
       return "GenzContinuous";
    }
    
-   /////////for test
+   // for testing
    public double getExactMean() {
-	   return exactMean;
-	}
+      return exactMean;
+   }
 }

--- a/src/main/docs/examples/rqmcexperiments/GenzCornerPeak.java
+++ b/src/main/docs/examples/rqmcexperiments/GenzCornerPeak.java
@@ -86,7 +86,7 @@ public class GenzCornerPeak implements MonteCarloModelDouble {
     * @throws IllegalArgumentException if @f$s \ge 63@f$, since @f$2^s@f$ subsets
     *         cannot be represented safely with a `long`
     */
-   public double computeExactMean() {
+   private double computeExactMean() {
 	   if (s >= 63) {
 	      throw new IllegalArgumentException(
 	         "Exact subset enumeration needs 2^s subsets; s is too large."
@@ -146,6 +146,10 @@ public class GenzCornerPeak implements MonteCarloModelDouble {
    @Override
    public String getTag() {
       return "GenzCornerPeak";
+   }
+   // for testing
+   public double getExactMean() {
+      return exactMean;
    }
 
 }

--- a/src/main/docs/examples/rqmcexperiments/GenzDiscontinuous.java
+++ b/src/main/docs/examples/rqmcexperiments/GenzDiscontinuous.java
@@ -29,7 +29,7 @@ public class GenzDiscontinuous implements MonteCarloModelDouble {
     *
     * @param s dimension of the function
     * @param c scale parameters, all strictly positive
-    * @param w discontinuity parameters, of length 2, both in @f$(0,1)@f$
+    * @param w discontinuity parameters, of length 2, both in @f$[0,1)@f$
     */
    public GenzDiscontinuous(int s, double[] c, double[] w) {
       if (s < 2)
@@ -108,7 +108,7 @@ public class GenzDiscontinuous implements MonteCarloModelDouble {
    public String getTag() {
       return "GenzDiscontinuous";
    }
-   /////////for test
+   // for testing
    public double getExactMean() {
 	   return exactMean;
 	}

--- a/src/main/docs/examples/rqmcexperiments/GenzGaussian.java
+++ b/src/main/docs/examples/rqmcexperiments/GenzGaussian.java
@@ -17,7 +17,7 @@ import umontreal.ssj.util.Num;
 public class GenzGaussian implements MonteCarloModelDouble {
 
    private final int s;
-   private final double[] cSquared; // Precomputed (C_j)^2 for simulate. C_j are needed only for exacte value
+   private final double[] cSquared; // Precomputed (C_j)^2 for simulate. C_j are needed only for exact value
    private final double[] w;
    private final double exactMean;
 
@@ -28,7 +28,7 @@ public class GenzGaussian implements MonteCarloModelDouble {
     *
     * @param s dimension of the function
     * @param c scale parameters, all strictly positive
-    * @param w location parameters, all in the open interval @f$(0,1)@f$
+    * @param w location parameters, all in the half-open interval @f$[0,1)@f$
     */
    public GenzGaussian(int s, double[] c, double[] w) {
       if (s <= 0)
@@ -102,6 +102,10 @@ public class GenzGaussian implements MonteCarloModelDouble {
    @Override
    public String getTag() {
       return "GenzGaussian";
+   }
+   // for testing
+   public double getExactMean() {
+      return exactMean;
    }
 
 }

--- a/src/main/docs/examples/rqmcexperiments/GenzOscillatory.java
+++ b/src/main/docs/examples/rqmcexperiments/GenzOscillatory.java
@@ -27,7 +27,7 @@ public class GenzOscillatory implements MonteCarloModelDouble {
     *
     * @param s dimension of the function
     * @param c scale parameters, all strictly positive
-    * @param w1 phase parameter in the open interval @f$(0,1)@f$
+    * @param w1 phase parameter in the half-open interval @f$[0,1)@f$
     */
    public GenzOscillatory(int s, double[] c, double w1) {
       if (s <= 0)
@@ -97,8 +97,8 @@ public class GenzOscillatory implements MonteCarloModelDouble {
       return "GenzOscillatory";
    }
    
-   /////////for test
+   // for testing
    public double getExactMean() {
-	   return exactMean;
-	}
+      return exactMean;
+   }
 }

--- a/src/main/docs/examples/rqmcexperiments/GenzProductPeak.java
+++ b/src/main/docs/examples/rqmcexperiments/GenzProductPeak.java
@@ -28,7 +28,7 @@ public class GenzProductPeak implements MonteCarloModelDouble {
     *
     * @param s dimension of the function
     * @param c scale parameters, all strictly positive
-    * @param w location parameters, all in the open interval @f$(0,1)@f$
+    * @param w location parameters, all in the half-open interval @f$[0,1)@f$
     */
    public GenzProductPeak(int s, double[] c, double[] w) {
       if (s <= 0)
@@ -100,5 +100,9 @@ public class GenzProductPeak implements MonteCarloModelDouble {
    @Override
    public String getTag() {
       return "GenzProductPeak";
+   }
+   // for testing
+   public double getExactMean() {
+      return exactMean;
    }
 }


### PR DESCRIPTION
Standardize Genz*.java examples by fixing [0,1) Javadoc ranges and adding missing getExactMean() accessors.