### PR TITLE
Develop/Otman: Update MeanMedianMSE; Update HistLatexCollection and SAMO examples docs.

### DIFF
--- a/src/main/docs/examples/rqmcexperiments/HistCollectionLatex.java
+++ b/src/main/docs/examples/rqmcexperiments/HistCollectionLatex.java
@@ -18,8 +18,8 @@ import umontreal.ssj.stat.ScaledHistogram;
  * class contains tools to do that. It assumes that the data files are
  * classified with multiple parameters, and organize the histograms with a
  * multidimensional ordering based on these parameters.
- * 
- * This class Is actually more specific. It assumes that each data file contains
+ *
+ * This class is actually more specific. It assumes that each data file contains
  * $m$ observations of a QMC or RQMC estimator for a given integrand (model), a
  * given number @f$s@f$ of dimensions, a given RQMC method, and a given number
  * of points @f$n = 2^k@f$. These four parameters classify the data sets and the
@@ -32,12 +32,12 @@ import umontreal.ssj.stat.ScaledHistogram;
  * of @f$s@f$ are put together in a large table, usually with one row for all
  * values of @f$k@f$ for each method. The rows of that table can cover several
  * letter-sized pages if many RQMC methods are considered.
- * 
+ *
  * The data files in the input directory are assumed to be named as follows.
  * Each model is identified by a short string called the model tag. Each file
  * name starts with its model tag, then the value of @f$s@f$, then the
  * identifier of the method, then the value of @f$k@f$, then the number @f$m@f$
- * of observations in the file. All the fields are separated bt the character
+ * of observations in the file. All the fields are separated by the character
  * `-`, The file extension is `.dat`. For example,
  * `Gaussian-2-Lat-RS-8-10000.dat` will be an input file that contains 10000
  * observations (real numbers) and nothing else, for the model `Gaussian` in 2
@@ -53,21 +53,22 @@ import umontreal.ssj.stat.ScaledHistogram;
  * (100 by default) can be changed by {@link #setNumBins}, and the number of
  * extreme observations that are marked on each side of the histogram (2 by
  * default) can be set by {@link #setExtremeMarks}.
- * 
- * The program {@link HistSamo25.java} gives an example of how to use this
+ *
+ * The program {@link HistSamo25} gives an example of how to use this
  * class. Before calling any method, one must specify the input and output
- * folders that contain the data files and the histograms, respectively. Then the set
- * of model tags, the set of method names, the set of dimensions @f$s@f$, the
- * set of values of @f$k@f$, and the number of observations per histogram, must
- * also be defined, to be passed as parameters. The method `fileNameMaker` in
- * the program will construct a file name as described above for each
- * combination of model, dimension, method, and value of @f$k@f$, and search for
- * that data file in the input folder. Output file names and page titles are
- * defined by {@code outputFileName} and {@code makePageTitle}. Those helper
- * methods can be adjusted in the source code if a different naming or title
- * convention is desired.
- * 
- * This class has no constructor; all the methods are static.
+ * folders that contain the data files and the generated histograms latex files, 
+ * respectively. Then the set of model tags, the set of method names, the set of
+ * dimensions @f$s@f$, the set of values of @f$k@f$, and the number of observations
+ * per histogram, must also be defined, to be passed as parameters. The method
+ * {@code fileNameMaker} in the program will construct a file name as described
+ * above for each combination of model, dimension, method, and value of @f$k@f$,
+ * and search for that data file in the input folder. Output file names and page
+ * titles are defined by {@code outputFileName} and {@code makePageTitle}.
+ * Those helper methods can be adjusted in the source code if a different naming
+ * or title convention is desired.
+ *
+ * This class has no public constructor; it is a static utility class, and
+ * all the methods are static.
  */
 
 public class HistCollectionLatex {

--- a/src/main/docs/examples/rqmcexperiments/HistSamo25.java
+++ b/src/main/docs/examples/rqmcexperiments/HistSamo25.java
@@ -3,11 +3,11 @@ package rqmcexperiments;
 import java.io.IOException;
 
 /**
- * Example that uses {@link HistCollectionLatex} to generate histograms in LaTeX files. 
+ * Example that uses {@link HistCollectionLatex} to generate histograms in LaTeX files.
  * The local variables in the `main` set the directories, list of models, list of methods,
  * dimensions, values of `k = log_2 n`, and number of observations.
  * All of these are passed as parameters to `HistCollectionLatex.writeCollection`,
- * which constructs one LaTeX file for for each model in the list.
+ * which constructs one LaTeX file for each model in the list.
  */
 public class HistSamo25 {
 

--- a/src/main/docs/examples/rqmcexperiments/MSESamo25.java
+++ b/src/main/docs/examples/rqmcexperiments/MSESamo25.java
@@ -4,12 +4,12 @@ import umontreal.ssj.rng.LFSR258;
 import umontreal.ssj.rng.RandomStream;
 
 /**
- * Example that uses {@link MeanMedianMSE} to generate tables for the MSEs of 
+ * Example that uses {@link MeanMedianMSE} to generate tables for the MSEs of
  * @f$A_r@f$, @f$M_r@f$, and their ratio. For each combination of model and
- * dimension @f$s@f$, three .res files are generated. Each file contains a 
- * data table whose columns are for the RQMC methods, the rows are for values of 
+ * dimension @f$s@f$, three .res files are generated. Each file contains a
+ * data table whose columns are for the RQMC methods, the rows are for values of
  * @f$k = \log_2 n@f$ where @f$n@f$ is the number of RQMC points,
- * and the entries are MSE or ratio values.   
+ * and the entries are MSE or ratio values.
  */
 public class MSESamo25 {
 
@@ -17,7 +17,7 @@ public class MSESamo25 {
     * Configures and runs MSE experiments with the samo25 data.
     */
    public static void main(String[] args) {
-      
+   
       String inputFolder = "C:/Users/Lecuyer/Dropbox/samo25/datapl/";
       String outputFolder = "C:/Users/Lecuyer/Dropbox/samo25/mse/";
       String[] modelTags = {"MC2"};
@@ -31,7 +31,7 @@ public class MSESamo25 {
       int[] ks = {8, 10, 12, 14, 16};
 
       int numObs = 10000;   // Number of observations in the input data files.
-      int numReps = 100000; // Number of replications to estimate the MSE.
+      int numReps = 100000; // Number of replications to estimate the MSE_Mr.
       int r = 11;           // Sample size for the mean or median estimator.
 
       RandomStream stream = new LFSR258();

--- a/src/main/docs/examples/rqmcexperiments/MeanMedianMSE.java
+++ b/src/main/docs/examples/rqmcexperiments/MeanMedianMSE.java
@@ -5,94 +5,148 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import umontreal.ssj.rng.LFSR258;
 import umontreal.ssj.rng.RandomStream;
 import umontreal.ssj.stat.Tally;
 import umontreal.ssj.stat.TallyStore;
 import umontreal.ssj.util.Misc;
 
 /**
- * Suppose we have a large number of independent observations from a given distribution
- * and we want to estimate the true mean of the distribution by picking a small number
- * @f$r@f$ of observations at random from the large set, with replacement, and taking either their
- * average @f$A_r@f$ or their median @f$M_r@f$ as an estimator of the mean.
+ * Suppose we have a large number of independent observations from a given
+ * distribution and we want to estimate the true mean of the distribution by
+ * picking a small number @f$r@f$ of observations at random from the large set,
+ * with replacement, and taking either their average @f$A_r@f$ or their median
+ * @f$M_r@f$ as an estimator of the mean.
  * We want to estimate the MSE of @f$A_r@f$ and @f$M_r@f$ and
  * the ratio @f$\mathrm{MSE}[A_r] / \mathrm{MSE}[M_r]@f$ to compare them.
- * The true mean is assumed to be known and given by the variable `ExactMean`.
- * It is zero by default, but can be changed via `setExactMean`.
- * To estimate the MSEs, we pick @f$r@f$ observations at random from the set
- * and compute the squares @f$A_r^2@f$ and @f$M_r^2@f$, repeat that @f$m@f$ times,
- * and take the averages. The method `computeMseArMr` does that. 
- * 
- * This class is organized to do this not only for a single distribution (data set), but for a large 
- * collection of data sets that are stored in data files in exactly the same way and with the
- * same naming convention as for the class `HistCollectionLatex.java`.
- * The top-level entry method is {@link computeFolderMSE}. It takes the input and output directories, 
- * a model tag (name), the number @f$s@f$ of dimensions, 
- * a set of RQMC method names, a set of values of @f$k@f$, the number of observations per input file, 
- * the number @f$m@f$ of replications to estimate the MSE, the value of @f$r@f$, and a random stream.
- * The input file names to search will be constructed based on this information. 
- * After estimating the two MSEs for each method and each @f$k@f$, three `.res` files will be created 
- * for this model and value of @f$s@f$, each one containing a table whose columns 
- * correspond to RQMC methods, the rows are for the values of @f$k@f$,
- * and the entries are the MSE or ratio values.  
+ * The true mean is assumed to be known and given by the variable {@code exactMean}.
+ * It is zero by default, but can be changed via {@link #setExactMean(double)}.
+ * To estimate the MSEs, @f$\mathrm{MSE}[A_r]@f$ is computed by
+ * {@link #mseAr(Tally, int)} directly from the empirical variance of the
+ * stored observations, using
+ * @f$\mathrm{Var}_{\mathrm{emp}}(X)/r + \mathrm{bias}^2@f$.
+ * For @f$M_r@f$, we pick @f$r@f$ observations at random from the set,
+ * compute @f$M_r@f$, repeat that @f$m@f$ times, and estimate the MSE from
+ * these values. The method
+ * {@link #bootstrapMrValues(TallyStore, int, int, RandomStream, TallyStore)}
+ * generates the @f$M_r@f$ values, and {@link #mse(Tally)} computes their
+ * MSE.
+ *
+ * This class is organized to do this not only for a single distribution (data
+ * set), but for a large collection of data sets that are stored in data files
+ * in exactly the same way and with the same naming convention as for the class
+ * {@link HistCollectionLatex}. The top-level entry method is
+ * {@link #computeFolderMSE}. It takes the input and output directories, a
+ * model tag (name), the number @f$s@f$ of dimensions, a set of RQMC method
+ * names, a set of values of @f$k@f$, the number of observations per input
+ * file, the number @f$m@f$ of replications to estimate the @f$\mathrm{MSE}[M_r]@f$, the value of
+ * @f$r@f$, and a random stream.
+ * The input file names to search will be constructed based on this information.
+ * After estimating the two MSEs for each method and each @f$k@f$, three
+ * {@code .res} files will be created for this model and value of @f$s@f$,
+ * each one containing a table whose columns correspond to RQMC methods, the
+ * rows are for the values of @f$k@f$, and the entries are the MSE or ratio
+ * values.
  */
 public class MeanMedianMSE {
+   /**
+    * Exact mean used to compute the bias in the MSE. Default is 0.0.
+    */
+   private static double exactMean = 0.0;
 
-   public static double ExactMean = 0.0;
+   private MeanMedianMSE() {
+      // Static utility class.
+   }
+
+   /**
+    * Sets the {@code exactMean} used as the target value in the MSE computations.
+    * The default value is 0.0. When computing results for several models, this
+    * value should be updated before processing each model if the exact mean is
+    * different.
+    *
+    * @param target exact mean for the current model
+    */
+   public static void setExactMean(double target) {
+      exactMean = target;
+   }
+
+   /**
+    * Returns the current value of {@code exactMean}.
+    * @return current value of {@code exactMean}
+    */
+   public static double getExactMean() {
+      return exactMean;
+   }
 
    /**
     * Computes the MSE from a tally of observations.
     *
     * @param tally tally containing the observations
-    * @return estimated MSE relative to {@link #ExactMean}
-   */
+    * @return estimated MSE relative to {@code exactMean}
+    */
    public static double mse(Tally tally) {
-      double bias = tally.average() - ExactMean;
-      return tally.variance() + bias * bias;
+      double bias = tally.average() - exactMean;
+      return tally.variance() * (tally.numberObs() - 1.0)
+         / tally.numberObs() + bias * bias;
    }
 
    /**
-    * Reads observations from an input data file and puts then in an array.
-    * 
+    * Computes the MSE of the average of @f$r@f$ observations sampled with
+    * replacement from the empirical distribution defined by the values in the
+    * tally using @f$\mathrm{Var}_{\mathrm{emp}}(X)/r + \mathrm{bias}^2@f$.
+    * This avoids using bootstrap for the average and computes the MSE directly
+    * from the stored observations.
+    *
+    * @param tally tally containing the observations
+    * @param r number of observations sampled and averaged
+    * @return estimated MSE relative to {@code exactMean}
+    */
+   public static double mseAr(Tally tally, int r) {
+      double bias = tally.average() - exactMean;
+      return tally.variance() * (tally.numberObs() - 1.0)
+         / tally.numberObs() / r + bias * bias;
+   }
+
+   /**
+    * Reads observations from an input data file and stores them in a TallyStore.
+    *
     * @param filename input data file
-    * @return array containing the observations
+    * @return TallyStore containing the observations
     * @throws IllegalArgumentException if the file contains no observations
-   */
-   public static double[] readDataValues(String filename) {
+    */
+   private static TallyStore readDataValues(String filename) {
       TallyStore tally = new TallyStore();
       // Use fillFromFile(filename, skip) if the file contains comments.
       tally.fillFromFile(filename);
       if (tally.numberObs() == 0)
          throw new IllegalArgumentException("No data values found in " + filename);
-      return tally.getArray();
+      return tally;
    }
 
    /**
-    * Performs bootstrap simulations to obtain realizations of @f$A_r@f$ and @f$M_r@f$,
-    * and store them in `statAver` and `statMed`.
-    * 
-    * **********  Better to re-use the same collectors and return them, so we can also 
-    *             look at the average, kurtosis, etc. if desired.         ***********************  
+    * Performs bootstrap simulations to obtain realizations of @f$M_r@f$,
+    * and store them in {@code statMed}.
     *
-    * @param values input data observations
+    * **********  Better to re-use the same collector and return it, so we can also
+    *             look at the average, kurtosis, etc. if desired.***********************
+    *             
+    *
+    * @param tally input data observations
     * @param m number of bootstrap samples
     * @param r size of each bootstrap sample
     * @param stream random stream used for sampling
-    * @return array containing the MSE of @f$A_r@f$ and @f$M_r@f$
+    * @param statMed TallyStore in which the @f$M_r@f$ values are stored
    */
-   public static void computeMSEArMr(double[] values, int m, int r, RandomStream stream,
-         TallyStore statAver, TallyStore statMed) {
-      int numSim = values.length;
+   public static void bootstrapMrValues(TallyStore tally, int m, int r,
+         RandomStream stream, TallyStore statMed) {
+      int numSim = tally.numberObs();
+      double[] values = tally.getArray();
       double[] sample = new double[r];
+      statMed.init(); // Clear previous observations.
       for (int i = 0; i < m; i++) {
-         double sum = 0.0;
          for (int j = 0; j < r; j++) {
             double value = values[stream.nextInt(0, numSim - 1)];
             sample[j] = value;
-            sum += value;
          }
-         statAver.add(sum / r);
          statMed.add(Misc.getMedian(sample, r));
       }
    }
@@ -104,7 +158,7 @@ public class MeanMedianMSE {
     * @param table formatted table
     * @throws RuntimeException if the file cannot be written
     */
-   public static void writeTable(File file, String table) {
+   private static void writeTable(File file, String table) {
       try (PrintWriter out = new PrintWriter(new FileWriter(file))) {
          out.print(table);
       } catch (IOException e) {
@@ -122,9 +176,9 @@ public class MeanMedianMSE {
     * @param method RQMC method name
     * @param k value of @f$k@f$
     * @param numObs number of observations contained in the filename
-    * @return the data file, or `null` if it is missing
+    * @return the data file, or {@code null} if it is missing
     */
-   public static File getDataFile(String inputFolder, String model,
+   private static File getDataFile(String inputFolder, String model,
          int s, String method, int k, int numObs) {
       String fileName = model + "-" + s + "-" + method
             + "-" + k + "-" + numObs + ".dat";
@@ -169,8 +223,7 @@ public class MeanMedianMSE {
       StringBuilder arRows = new StringBuilder();
       StringBuilder mrRows = new StringBuilder();
       StringBuilder ratioRows = new StringBuilder();
-      
-      TallyStore statAver = new TallyStore("A_r");
+
       TallyStore statMed = new TallyStore("M_r");
       for (int i = 0; i < ks.length; i++) {
          int k = ks[i];
@@ -189,15 +242,15 @@ public class MeanMedianMSE {
                ratioRows.append("Missing  ");
                continue;
             }
-            double[] values = readDataValues(file.getAbsolutePath());
+            TallyStore tally = readDataValues(file.getAbsolutePath());
             // Reuse the same substream for every method at this k.
             stream.resetStartSubstream();
-            computeMSEArMr(values, m, r, stream, statAver, statMed);
-            double arMse = mse(statAver);
-            double mrMse = mse(statMed);        
+            bootstrapMrValues(tally, m, r, stream, statMed);
+            double arMse = mseAr(tally, r);
+            double mrMse = mse(statMed);
             arRows.append(arMse).append("  ");
             mrRows.append(mrMse).append("  ");
-            ratioRows.append(arMse / mrMse).append("  ");
+            ratioRows.append(mrMse == 0.0 ? Double.NaN : arMse / mrMse).append("  ");
          }
          arRows.append("\n");
          mrRows.append("\n");

--- a/src/main/docs/examples/rqmcexperiments/MeanMedianMSE.java
+++ b/src/main/docs/examples/rqmcexperiments/MeanMedianMSE.java
@@ -128,7 +128,7 @@ public class MeanMedianMSE {
     *
     * **********  Better to re-use the same collector and return it, so we can also
     *             look at the average, kurtosis, etc. if desired.***********************
-    *             
+    *      
     *
     * @param tally input data observations
     * @param m number of bootstrap samples


### PR DESCRIPTION
This PR :
Updates MeanMedianMSE to compute MSE_Ar directly from empirical variance and bootstrap only MSE_Mr. 
Encapsulates the exact mean with getter/setter methods, makes internal helpers private, handles zero MSE_Mr ratios as NaN.
Fixes  documentation in MeanMedianMSE, HistLatexCollection and SAMO examples.